### PR TITLE
[#22] 소셜 로그인 OAuth Server 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ yarn-error.log*
 next-env.d.ts
 
 .vscode
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 next-env.d.ts
 
 .vscode
+.env

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -17,7 +17,7 @@ export default function Login() {
       <section className="flex flex-col mt-5 space-y-3">
         <button onClick={() => signIn('kakao')}>카카오톡 로그인</button>
         <button>네이버 로그인</button>
-        <button>구글 로그인</button>
+        <button onClick={() => signIn('google')}>구글 로그인</button>
         <button>애플 로그인</button>
       </section>
       <section className="flex flex-col mt-5 space-y-3">

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -16,7 +16,7 @@ export default function Login() {
       />
       <section className="flex flex-col mt-5 space-y-3">
         <button onClick={() => signIn('kakao')}>카카오톡 로그인</button>
-        <button>네이버 로그인</button>
+        <button onClick={() => signIn('naver')}>네이버 로그인</button>
         <button onClick={() => signIn('google')}>구글 로그인</button>
         <button>애플 로그인</button>
       </section>

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -18,7 +18,6 @@ export default function Login() {
         <button onClick={() => signIn('kakao')}>카카오톡 로그인</button>
         <button onClick={() => signIn('naver')}>네이버 로그인</button>
         <button onClick={() => signIn('google')}>구글 로그인</button>
-        <button>애플 로그인</button>
       </section>
       <section className="flex flex-col mt-5 space-y-3">
         {session && session.user && (

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,6 @@
 import NextAuth from 'next-auth';
 import KakaoProvider from 'next-auth/providers/kakao';
+import GoogleProvider from 'next-auth/providers/google';
 
 const handler = NextAuth({
   providers: [
@@ -7,19 +8,15 @@ const handler = NextAuth({
       clientId: `${process.env.KAKAO_CLIENT_ID}`,
       clientSecret: `${process.env.KAKAO_CLIENT_SECRET}`,
     }),
+    GoogleProvider({
+      clientId: `${process.env.GOOGLE_CLIENT_ID}`,
+      clientSecret: `${process.env.GOOGLE_CLIENT_SECRET}`,
+    }),
   ],
   callbacks: {
-    // 로그인이 완료되었을 때 백엔드와 연동 로직 여기에 추가
     async signIn(data) {
       try {
-        // TODO:
-        // data params 로 받아오는 데이터를 백엔드에 전달
-        // 해당 유저에 대한 액세스 토큰 발급 및 저장하여 api 요청시 활용
-        // 만약 이렇게 발급받은 액세스 토큰이 만료된 경우에는 어떻게 해야하지?
-        // -> 리프레시 토큰을 이용해서 우리 서버의 액세스 토큰 재발급
-        // 카카오 서버에서 발급받은 액세스 토큰이 만료된 경우
-        // -> 프론트쪽에서 카카오 서버를 통해 갱신 필요
-        // 여기서 우리 서버의 액세스토큰과 리프레시토큰을 어떤 전략으로 관리할 것인지 결정 필요
+        // TODO: 백엔드 회원가입/로그인 api 요청 here
         console.log(data);
         return true;
       } catch {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -19,10 +19,17 @@ const handler = NextAuth({
     }),
   ],
   callbacks: {
-    async signIn(data) {
+    async signIn({ user, account }) {
       try {
+        const body = {
+          email: user.email,
+          gender: null,
+          age: null,
+          socialType: account?.provider,
+        };
+
         // TODO: 백엔드 회원가입/로그인 api 요청 here
-        console.log(data);
+        console.log(body);
         return true;
       } catch {
         return false;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,7 @@
 import NextAuth from 'next-auth';
 import KakaoProvider from 'next-auth/providers/kakao';
 import GoogleProvider from 'next-auth/providers/google';
+import NaverProvider from 'next-auth/providers/naver';
 
 const handler = NextAuth({
   providers: [
@@ -11,6 +12,10 @@ const handler = NextAuth({
     GoogleProvider({
       clientId: `${process.env.GOOGLE_CLIENT_ID}`,
       clientSecret: `${process.env.GOOGLE_CLIENT_SECRET}`,
+    }),
+    NaverProvider({
+      clientId: `${process.env.NAVER_CLIENT_ID}`,
+      clientSecret: `${process.env.NAVER_CLIENT_SECRET}`,
     }),
   ],
   callbacks: {


### PR DESCRIPTION
### PR 제목 (Title)

소셜 로그인 OAuth Server 연동

### 변경 사항 (Changes)

* 체크리스트
  - [x] 구글 소셜로그인 연동 추가
  - [x] 네이버 소셜 로그인 추가
  - [x] 로그인을 위해 필요한 유저 데이터 추출
  - #22 

### 변경 이유 (Reason for Changes)

* 로그인 api 연동 밑작업

### 테스트 방법 (Test Procedure)

* 로컬로 실행 후 localhost:3000/login 경로에서 테스트 가능
* 구글 로그인의 경우 테스트용으로 등록된 구글 계정만 가능하므로 테스트 원하면 계정 추가 요청 바람

### 참고 사항 (Additional Information)

* 애플로그인은 비용 이슈로 잠시 보류
* 디자인 적용되지 않은 관계로 추후 수정 예정
* api 요청 로직은 제외됨, 구조 어떻게 가져갈 것인지 ~ api 에서 api로 요청 어떤식으로 보내는지 확인 후 적용 예정
* 소셜로그인 키값은 디스코드로 공유, .env 생성하여 각자 적용 필요