### PR TITLE
[#61] 히스토리 페이지 퍼블리싱

### DIFF
--- a/src/app/(primary)/rating/page.tsx
+++ b/src/app/(primary)/rating/page.tsx
@@ -8,6 +8,7 @@ import { Alcohol } from '@/types/Alcohol';
 
 export default function Rating() {
   const router = useRouter();
+  // TODO: & FIXME: 실제 데이터로 변경 && 무한 스크롤 적용
   const [populars, setPopulars] = useState<Alcohol[]>([]);
   const [currentCategory, setCurrentCategory] = useState('All');
   const handleCategory = (value: string) => {

--- a/src/app/(primary)/user/[id]/_components/HistoryOverview.tsx
+++ b/src/app/(primary)/user/[id]/_components/HistoryOverview.tsx
@@ -1,26 +1,35 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 // TODO: 실제 api dto 에 맞출것
 interface Props {
   rates: number;
   reviews: number;
   likes: number;
+  id: number;
 }
 
-const HistoryOverview = ({ rates, reviews, likes }: Props) => {
-  const MOCK_HISTORY_OVERVIEW = [
-    { name: '별점', value: rates },
-    { name: '리뷰', value: reviews },
-    { name: '찜하기', value: likes },
+const HistoryOverview = ({ rates, reviews, likes, id }: Props) => {
+  const router = useRouter();
+
+  const HISTORY_OVERVIEW = [
+    { name: '별점', value: rates, link: `/user/${id}/history?type=rating` },
+    { name: '리뷰', value: reviews, link: `/user/${id}/history?type=review` },
+    { name: '찜하기', value: likes, link: `/user/${id}/history?type=pick` },
   ];
 
   return (
     <article className="flex justify-center pt-2.75 divide-x divide-subCoral divide-opacity-30 text-fontBurgundy">
-      {MOCK_HISTORY_OVERVIEW.map((item) => (
-        <p className="flex flex-col items-center px-8.5" key={item.name}>
-          <span className="text-[2.125rem] font-bold text-subCoral">
-            {item.value}
-          </span>
-          <span className="text-sm whitespace-nowrap">{item.name}</span>
-        </p>
+      {HISTORY_OVERVIEW.map((item) => (
+        <button onClick={() => router.push(item.link)}>
+          <p className="flex flex-col items-center px-8.5" key={item.name}>
+            <span className="text-[2.125rem] font-bold text-subCoral">
+              {item.value}
+            </span>
+            <span className="text-sm whitespace-nowrap">{item.name}</span>
+          </p>
+        </button>
       ))}
     </article>
   );

--- a/src/app/(primary)/user/[id]/history/page.tsx
+++ b/src/app/(primary)/user/[id]/history/page.tsx
@@ -1,19 +1,26 @@
 'use client';
 
+import EmptyView from '@/app/(primary)/_components/EmptyView';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
+import { AlcoholsApi } from '@/app/api/AlcholsApi';
+import List from '@/components/List/List';
 import Tab from '@/components/Tab';
 import { HISTORY_TYPES } from '@/constants/user';
 import { useTab } from '@/hooks/useTab';
+import { Alcohol } from '@/types/Alcohol';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function UserHistory() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const historyType = searchParams.get('type');
-
   const { currentTab, handleTab, tabList } = useTab({ tabList: HISTORY_TYPES });
+  const [populars, setPopulars] = useState<Alcohol[]>([]);
+  const [filterOptions, setFilterOptions] = useState<
+    { id: number; value: string }[] | null
+  >(null);
 
   useEffect(() => {
     const selected = tabList.find((item) => item.id === historyType);
@@ -24,6 +31,23 @@ export default function UserHistory() {
   useEffect(() => {
     router.replace(`?type=${currentTab.id}`);
   }, [currentTab]);
+
+  const SORT_OPTIONS = ['인기도순', '별점순', '찜하기순', '댓글순'];
+
+  useEffect(() => {
+    (async () => {
+      console.log('호출되나용?');
+      const result = await AlcoholsApi.getRegion();
+      setFilterOptions(result);
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const result = await AlcoholsApi.getPopular();
+      setPopulars(result);
+    })();
+  }, []);
 
   return (
     <main>
@@ -45,8 +69,25 @@ export default function UserHistory() {
         </SubHeader.Center>
       </SubHeader>
 
-      <section className="pt-10 px-5">
+      <section className="pt-10 px-5 space-y-7.5">
         <Tab currentTab={currentTab} handleTab={handleTab} />
+
+        <List>
+          {filterOptions && (
+            <List.Manager
+              total={populars.length}
+              sortOptions={SORT_OPTIONS}
+              hanldeSortOption={(value) => console.log(value)}
+              filterOptions={filterOptions}
+            />
+          )}
+
+          {populars.map((item: any) => (
+            <List.Item key={item.alcoholId} data={item} />
+          ))}
+
+          {!populars.length && <EmptyView />}
+        </List>
       </section>
     </main>
   );

--- a/src/app/(primary)/user/[id]/history/page.tsx
+++ b/src/app/(primary)/user/[id]/history/page.tsx
@@ -22,7 +22,7 @@ export default function UserHistory() {
   }, [historyType]);
 
   useEffect(() => {
-    router.push(`?type=${currentTab.id}`);
+    router.replace(`?type=${currentTab.id}`);
   }, [currentTab]);
 
   return (

--- a/src/app/(primary)/user/[id]/history/page.tsx
+++ b/src/app/(primary)/user/[id]/history/page.tsx
@@ -1,5 +1,53 @@
-import React from 'react';
+'use client';
+
+import { SubHeader } from '@/app/(primary)/_components/SubHeader';
+import Tab from '@/components/Tab';
+import { HISTORY_TYPES } from '@/constants/user';
+import { useTab } from '@/hooks/useTab';
+import Image from 'next/image';
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { useEffect } from 'react';
 
 export default function UserHistory() {
-  return <div>UserHistory page</div>;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const historyType = searchParams.get('type');
+
+  const { currentTab, handleTab, tabList } = useTab({ tabList: HISTORY_TYPES });
+
+  useEffect(() => {
+    const selected = tabList.find((item) => item.id === historyType);
+
+    handleTab(selected?.id ?? 'all');
+  }, [historyType]);
+
+  useEffect(() => {
+    router.push(`?type=${currentTab.id}`);
+  }, [currentTab]);
+
+  return (
+    <main>
+      <SubHeader bgColor="bg-bgGray">
+        <SubHeader.Left
+          onClick={() => {
+            router.back();
+          }}
+        >
+          <Image
+            src="/icon/arrow-left-subcoral.svg"
+            alt="arrowIcon"
+            width={23}
+            height={23}
+          />
+        </SubHeader.Left>
+        <SubHeader.Center textColor="text-subCoral">
+          마이페이지
+        </SubHeader.Center>
+      </SubHeader>
+
+      <section className="pt-10 px-5">
+        <Tab currentTab={currentTab} handleTab={handleTab} />
+      </section>
+    </main>
+  );
 }

--- a/src/app/(primary)/user/[id]/page.tsx
+++ b/src/app/(primary)/user/[id]/page.tsx
@@ -11,7 +11,7 @@ import SidebarHeader from './_components/SidebarHeader';
 // 1. 유저 데이터 가져오는 api 연동
 // 2. 활동 내역 가져오는 api 연동
 // 3. 기타 버튼 액션과 관련된 api 연동
-export default function User() {
+export default function User({ params: { id } }: { params: { id: string } }) {
   return (
     <main className="w-full h-full text-mainBlack mb-24">
       <section className="bg-bgGray p-7.5 pb-7">
@@ -22,7 +22,7 @@ export default function User() {
           following={12}
           isFollowing
         />
-        <HistoryOverview rates={52} reviews={12} likes={14} />
+        <HistoryOverview rates={52} reviews={12} likes={14} id={Number(id)} />
       </section>
 
       <section className="px-5 pt-9">

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,0 +1,26 @@
+import { HISTORY_TYPES } from '@/constants/user';
+
+interface Props {
+  currentTab: { name: string; id: string };
+  handleTab: (id: string) => void;
+}
+
+const Tab = ({ currentTab, handleTab }: Props) => {
+  return (
+    <div className="flex gap-3 relative">
+      {HISTORY_TYPES.map((type, idx) => {
+        return (
+          <button
+            key={type.id}
+            className={`${currentTab.id === type.id ? 'tab-selected' : 'tab-default'} pb-2 w-full font-bold text-[0.938rem] text-center leading-[17.2px]`}
+            onClick={() => handleTab(type.id)}
+          >
+            {type.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Tab;

--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -1,0 +1,18 @@
+export const HISTORY_TYPES = [
+  {
+    id: 'all',
+    name: '전체',
+  },
+  {
+    id: 'rating',
+    name: '별점',
+  },
+  {
+    id: 'review',
+    name: '리뷰',
+  },
+  {
+    id: 'pick',
+    name: '찜',
+  },
+];

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+interface Props {
+  tabList: { name: string; id: string }[];
+}
+
+export const useTab = ({ tabList }: Props) => {
+  const [currentTab, setCurrentTab] = useState(tabList[0]);
+
+  const handleTab = (id: string) => {
+    const selected = tabList.find((item) => item.id === id);
+
+    setCurrentTab((prev) => selected ?? prev);
+  };
+
+  return { currentTab, handleTab, tabList };
+};


### PR DESCRIPTION
### PR 제목 (Title)

[#61] 히스토리 페이지 퍼블리싱

### 변경 사항 (Changes)

  - [x] Tab 및 useTab 훅으로 Tab 컴포넌트 공통화
  - [x] 탭 이동해서 type 쿼리 변경되도록 수정 - 추후 해당 조건으로 필터링하여 api 연동 예정
  - [x] 히스토리 페이지 List 컴포넌트 추가

### 테스트 방법 (Test Procedure)

`/user/1` 페이지로 접근하여 별점, 리뷰, 찜 등... 갯수가 나온 부분을 클릭하면 페이지 이동됩니다.

### 참고 사항 (Additional Information)

<img width="376" alt="image" src="https://github.com/bottle-note/bottle-note-frontend/assets/89173923/7efa8453-2ef2-41d0-9946-ca34c9286309">


* 여러 페이지에 리스트 컴포넌트를 추가하다보니 List.Manager 리팩토링 및 해당 로직에 대한 공통 훅을 생성해야할 필요성을 느꼈습니다...
* 너무 과도하게 props 를 넘기는 것 같아 이 부분을 또 합성 패턴으로 변경해서 적용을 해보려고 해요... 합성 컴포넌트가 아니더라도 뭔가 더 좋은 방법이 없을까 고민이 되네욤... 흠 :\ 
* Tab 컴포넌트가 공통화되어서 만약 다음에 또 Tab을 사용할 일이 있거나 코드를 간소화 하고싶으시면 공통 로직을 활용해주시면 될 것 같습니다.
