### PR TITLE
[#98] 공통 Modal 기능 구현 및 review에 공통 modal 적용

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -159,6 +159,10 @@ module.exports = {
             group: 'internal',
           },
           {
+            pattern: 'store/**',
+            group: 'internal',
+          },
+          {
             pattern: 'constants/**',
             group: 'internal',
             position: 'after',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^18",
     "react-hook-form": "^7.52.0",
     "ts-jest": "^29.1.2",
-    "yup": "^1.4.0"
+    "yup": "^1.4.0",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.4",

--- a/src/app/(primary)/_components/LikeBtn.tsx
+++ b/src/app/(primary)/_components/LikeBtn.tsx
@@ -5,9 +5,9 @@ import { useSession } from 'next-auth/react';
 
 interface Props {
   isLiked: boolean;
-  setIsLiked: React.Dispatch<React.SetStateAction<boolean>>;
   likeBtnName?: string;
-  setLikedCount?: React.Dispatch<React.SetStateAction<number>>;
+  handleUpdateLiked: () => void;
+  handleRollback: () => void;
   likeIconColor?: 'white' | 'subcoral';
   unLikeIconColor?: 'gray' | 'subcoral';
   size?: number;
@@ -15,9 +15,9 @@ interface Props {
 
 const LikeBtn = ({
   isLiked,
-  setIsLiked,
   likeBtnName,
-  setLikedCount,
+  handleUpdateLiked,
+  handleRollback,
   unLikeIconColor = 'gray',
   likeIconColor = 'subcoral',
   size = 14,
@@ -28,22 +28,13 @@ const LikeBtn = ({
       alert('로그인이 필요한 서비스입니다.');
       return;
     } else {
-      const originalIsLiked = isLiked;
-      setIsLiked(!isLiked);
-      setLikedCount &&
-        setLikedCount((prevCount) => {
-          return prevCount + 1;
-        });
+      handleUpdateLiked();
       try {
         // api 호출
       } catch (error) {
         alert('업데이트에 실패했습니다. 다시 시도해주세요.');
         console.error('Error updating like status:', error);
-        setIsLiked(originalIsLiked);
-        setLikedCount &&
-          setLikedCount((prevCount) => {
-            return prevCount - 1;
-          });
+        handleRollback();
       }
     }
   };

--- a/src/app/(primary)/_components/LikeBtn.tsx
+++ b/src/app/(primary)/_components/LikeBtn.tsx
@@ -8,6 +8,7 @@ interface Props {
   likeBtnName?: string;
   handleUpdateLiked: () => void;
   handleRollback: () => void;
+  handleNotLogin: () => void;
   likeIconColor?: 'white' | 'subcoral';
   unLikeIconColor?: 'gray' | 'subcoral';
   size?: number;
@@ -18,6 +19,7 @@ const LikeBtn = ({
   likeBtnName,
   handleUpdateLiked,
   handleRollback,
+  handleNotLogin,
   unLikeIconColor = 'gray',
   likeIconColor = 'subcoral',
   size = 14,
@@ -25,8 +27,7 @@ const LikeBtn = ({
   const { data: session } = useSession();
   const handleClick = async () => {
     if (!session) {
-      alert('로그인이 필요한 서비스입니다.');
-      return;
+      handleNotLogin();
     } else {
       handleUpdateLiked();
       try {

--- a/src/app/(primary)/_components/LoginModal.tsx
+++ b/src/app/(primary)/_components/LoginModal.tsx
@@ -25,10 +25,8 @@ function LoginModal({ handleClose }: Props) {
             />
           </article>
           <article>
-            <p className="text-15 text-subCoral font-medium">
-              로그인이 필요한 서비스입니다.
-            </p>
-            <p className="text-13 text-mainDarkGray">로그인 하시겠습니까?</p>
+            <p className="modal-mainText">로그인이 필요한 서비스입니다.</p>
+            <p className="modal-subText">로그인 하시겠습니까?</p>
           </article>
           <Button
             btnName="로그인"

--- a/src/app/(primary)/_components/LoginModal.tsx
+++ b/src/app/(primary)/_components/LoginModal.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import BackDrop from '@/components/BackDrop';
-import { DualButton } from '@/components/Button';
+import { Button } from '@/components/Button';
 
 interface Props {
   handleClose: () => void;
@@ -30,15 +30,12 @@ function LoginModal({ handleClose }: Props) {
             </p>
             <p className="text-13 text-mainDarkGray">로그인 하시겠습니까?</p>
           </article>
-          {/* <button
-            className="w-full bg-subCoral rounded-xl py-4 text-white drop-shadow-md"
+          <Button
+            btnName="로그인"
             onClick={() => {
               router.push('/login');
             }}
-          >
-            로그인
-          </button> */}
-          <DualButton onClickCancel={() => {}} onClickOkay={() => {}} />
+          />
           <button className="text-10 text-mainGray pb-2" onClick={handleClose}>
             다음에 할게요
           </button>

--- a/src/app/(primary)/_components/PickBtn.tsx
+++ b/src/app/(primary)/_components/PickBtn.tsx
@@ -6,7 +6,8 @@ import { AlcoholsApi } from '@/app/api/AlcholsApi';
 
 interface Props {
   isPicked: boolean;
-  setIsPicked: React.Dispatch<React.SetStateAction<boolean>>;
+  handleUpdatePicked: () => void;
+  handleRollback: () => void;
   pickBtnName?: string;
   iconColor?: 'white' | 'subcoral';
   size?: number;
@@ -15,7 +16,8 @@ interface Props {
 
 const PickBtn = ({
   isPicked,
-  setIsPicked,
+  handleUpdatePicked,
+  handleRollback,
   alcoholId,
   pickBtnName,
   iconColor = 'white',
@@ -27,14 +29,13 @@ const PickBtn = ({
       alert('로그인이 필요한 서비스입니다.');
       return;
     } else {
-      const originalIsPicked = isPicked;
-      setIsPicked(!isPicked);
+      handleUpdatePicked();
       try {
         await AlcoholsApi.putPick(alcoholId, !isPicked);
       } catch (error) {
         alert('업데이트에 실패했습니다. 다시 시도해주세요.');
         console.error('Error updating pick status:', error);
-        setIsPicked(originalIsPicked);
+        handleRollback();
       }
     }
   };

--- a/src/app/(primary)/_components/PickBtn.tsx
+++ b/src/app/(primary)/_components/PickBtn.tsx
@@ -8,6 +8,7 @@ interface Props {
   isPicked: boolean;
   handleUpdatePicked: () => void;
   handleRollback: () => void;
+  handleNotLogin: () => void;
   pickBtnName?: string;
   iconColor?: 'white' | 'subcoral';
   size?: number;
@@ -18,16 +19,17 @@ const PickBtn = ({
   isPicked,
   handleUpdatePicked,
   handleRollback,
+  handleNotLogin,
   alcoholId,
   pickBtnName,
   iconColor = 'white',
   size = 14,
 }: Props) => {
   const { data: session } = useSession();
+
   const handleClick = async () => {
     if (!session) {
-      alert('로그인이 필요한 서비스입니다.');
-      return;
+      handleNotLogin();
     } else {
       handleUpdatePicked();
       try {

--- a/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
+++ b/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
@@ -14,11 +14,8 @@ interface Props {
 
 function AlcoholInfo({ data }: Props) {
   const router = useRouter();
-  const [isPicked, setIsPicked] = useState<boolean>(false);
-
-  useEffect(() => {
-    setIsPicked(data.isPicked);
-  }, [data]);
+  const { isPicked: originalIsPicked } = data;
+  const [isPicked, setIsPicked] = useState<boolean>(originalIsPicked);
 
   return (
     <section className="relative z-10 flex px-5 pb-6 space-x-5">
@@ -71,7 +68,8 @@ function AlcoholInfo({ data }: Props) {
             <div className="border-[0.5px] border-white my-[0.1rem]" />
             <PickBtn
               isPicked={isPicked}
-              setIsPicked={setIsPicked}
+              handleUpdatePicked={() => setIsPicked(!isPicked)}
+              handleRollback={() => setIsPicked(originalIsPicked)}
               pickBtnName="찜하기"
               alcoholId={data.alcoholId}
             />

--- a/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
+++ b/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
@@ -38,7 +38,7 @@ function AlcoholInfo({ data }: Props) {
       <article className="w-2/3 py-3 text-white space-y-2 overflow-x-hidden">
         <div className="space-y-1">
           <Label
-            name={data.korCategoryName}
+            name={data.korCategory}
             style={'border-white px-2 py-[0.15rem] rounded-md text-10'}
           />
           <h1 className="text-15 font-semibold whitespace-normal break-words">

--- a/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
+++ b/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
 import Label from '@/app/(primary)/_components/Label';
 import { truncStr } from '@/utils/truncStr';
@@ -10,73 +11,81 @@ import type { AlcoholInfo } from '@/types/Review';
 
 interface Props {
   data: AlcoholInfo;
+  handleLogin: () => void;
 }
 
-function AlcoholInfo({ data }: Props) {
+function AlcoholInfo({ data, handleLogin }: Props) {
   const router = useRouter();
+  const { data: session } = useSession();
   const { isPicked: originalIsPicked } = data;
   const [isPicked, setIsPicked] = useState<boolean>(originalIsPicked);
 
   return (
-    <section className="relative z-10 flex px-5 pb-6 space-x-5">
-      <div className="rounded-lg w-1/3 bg-white p-4">
-        <article className="relative h-[120px]">
-          {data.imageUrl && (
-            <Image
-              priority
-              src={data.imageUrl}
-              alt="img"
-              fill
-              className="object-contain"
-            />
-          )}
-        </article>
-      </div>
-      <article className="w-2/3 py-3 text-white space-y-2 overflow-x-hidden">
-        <div className="space-y-1">
-          <Label
-            name={data.korCategory}
-            style={'border-white px-2 py-[0.15rem] rounded-md text-10'}
-          />
-          <h1 className="text-15 font-semibold whitespace-normal break-words">
-            {data.korName && truncStr(data.korName, 27)}
-          </h1>
-          <p className="text-13 whitespace-normal break-words">
-            {data.engName && truncStr(data.engName.toUpperCase(), 45)}
-          </p>
-        </div>
-        <div className="space-y-1">
-          <div className="border-[0.5px] border-white" />
-          <div className="flex space-x-3">
-            <div
-              className="text-10 flex"
-              onClick={() => {
-                data.alcoholId &&
-                  router.push(`/review/register?alcoholId=${data.alcoholId}`);
-              }}
-            >
+    <>
+      <section className="relative z-10 flex px-5 pb-6 space-x-5">
+        <div className="rounded-lg w-1/3 bg-white p-4">
+          <article className="relative h-[120px]">
+            {data.imageUrl && (
               <Image
-                className="mr-1"
-                src="/icon/edit-outlined-white.svg"
-                alt="write"
-                width={16}
-                height={16}
+                priority
+                src={data.imageUrl}
+                alt="img"
+                fill
+                className="object-contain"
               />
-              {/* 추후 user당 하루 리뷰 count 확인하는 API 연동 필요*/}
-              <button>리뷰 작성</button>
-            </div>
-            <div className="border-[0.5px] border-white my-[0.1rem]" />
-            <PickBtn
-              isPicked={isPicked}
-              handleUpdatePicked={() => setIsPicked(!isPicked)}
-              handleRollback={() => setIsPicked(originalIsPicked)}
-              pickBtnName="찜하기"
-              alcoholId={data.alcoholId}
-            />
-          </div>
+            )}
+          </article>
         </div>
-      </article>
-    </section>
+        <article className="w-2/3 py-3 text-white space-y-2 overflow-x-hidden">
+          <div className="space-y-1">
+            <Label
+              name={data.korCategory}
+              style={'border-white px-2 py-[0.15rem] rounded-md text-10'}
+            />
+            <h1 className="text-15 font-semibold whitespace-normal break-words">
+              {data.korName && truncStr(data.korName, 27)}
+            </h1>
+            <p className="text-13 whitespace-normal break-words">
+              {data.engName && truncStr(data.engName.toUpperCase(), 45)}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <div className="border-[0.5px] border-white" />
+            <div className="flex space-x-3">
+              <div
+                className="text-10 flex"
+                onClick={() => {
+                  if (session && data.alcoholId) {
+                    router.push(`/review/register?alcoholId=${data.alcoholId}`);
+                  } else {
+                    handleLogin();
+                  }
+                }}
+              >
+                <Image
+                  className="mr-1"
+                  src="/icon/edit-outlined-white.svg"
+                  alt="write"
+                  width={16}
+                  height={16}
+                />
+                {/* 추후 user당 하루 리뷰 count 확인하는 API 연동 필요*/}
+                <button>리뷰 작성</button>
+              </div>
+              <div className="border-[0.5px] border-white my-[0.1rem]" />
+              <PickBtn
+                isPicked={isPicked}
+                handleUpdatePicked={() => setIsPicked(!isPicked)}
+                handleRollback={() => setIsPicked(originalIsPicked)}
+                handleNotLogin={handleLogin}
+                pickBtnName="찜하기"
+                alcoholId={data.alcoholId}
+              />
+            </div>
+          </div>
+        </article>
+      </section>
+    </>
   );
 }
 

--- a/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
+++ b/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
@@ -18,9 +18,11 @@ import { ReviewDetailsWithoutAlcoholInfo } from '@/types/Review';
 
 interface Props {
   data: ReviewDetailsWithoutAlcoholInfo;
+  handleShare: () => void;
+  handleLogin: () => void;
 }
 
-function ReviewDetails({ data }: Props) {
+function ReviewDetails({ data, handleShare, handleLogin }: Props) {
   const router = useRouter();
   const { data: session } = useSession();
   const [isShowStatus, setIsShowStatus] = useState<boolean>(true);
@@ -202,23 +204,45 @@ function ReviewDetails({ data }: Props) {
         </section>
         <section className="mx-5 py-5 flex items-center space-x-4">
           <div className="flex-1 flex text-center justify-center items-center space-x-1">
-            <Image
-              src={
-                data.reviewResponse?.isLikedByMe
-                  ? '/icon/thumbup-filled-subcoral.svg'
-                  : '/icon/thumbup-outlined-gray.svg'
-              }
-              width={16}
-              height={16}
-              alt="like"
-            />
-            <div className="text-mainGray font-bold text-10">좋아요</div>
+            <button
+              className="flex justify-center items-center space-x-1"
+              onClick={() => {
+                if (!session) {
+                  handleLogin();
+                  return;
+                } else {
+                  // api 적용 필요
+                }
+              }}
+            >
+              <Image
+                src={
+                  data.reviewResponse?.isLikedByMe
+                    ? '/icon/thumbup-filled-subcoral.svg'
+                    : '/icon/thumbup-outlined-gray.svg'
+                }
+                width={16}
+                height={16}
+                alt="like"
+              />
+              <div className="text-mainGray font-bold text-10">좋아요</div>
+            </button>
             <div className=" text-mainGray text-10 font-normal">
               좋아요 {data.reviewResponse?.likeCount}
             </div>
           </div>
           <span className="border-[0.01rem] w-px border-mainGray opacity-40 h-4" />
-          <div className="flex-1 flex text-center justify-center items-center space-x-1">
+          <div
+            className="flex-1 flex text-center justify-center items-center space-x-1"
+            onClick={() => {
+              if (!session) {
+                handleLogin();
+                return;
+              } else {
+                // api 적용 필요
+              }
+            }}
+          >
             <Image
               src={
                 data.reviewResponse?.hasReplyByMe
@@ -239,6 +263,7 @@ function ReviewDetails({ data }: Props) {
             onClick={() => {
               shareOrCopy(
                 `${process.env.NEXT_PUBLIC_BOTTLE_NOTE_URL}/review/${data.reviewResponse?.reviewId}`,
+                handleShare,
               );
             }}
           >

--- a/src/app/(primary)/review/[id]/page.tsx
+++ b/src/app/(primary)/review/[id]/page.tsx
@@ -16,13 +16,28 @@ import type {
   AlcoholInfo as AlcoholInfoType,
   ReviewDetailsWithoutAlcoholInfo,
 } from '@/types/Review';
+import useModalStore from '@/store/modalStore';
+import Modal from '@/components/Modal';
+import LoginModal from '@/app/(primary)/_components/LoginModal';
 
 export default function ReviewDetail() {
   const router = useRouter();
   const { id: reviewId } = useParams();
+  const { showModal, handleModal } = useModalStore();
   const [alcoholInfo, setAlcoholInfo] = useState<AlcoholInfoType | null>(null);
   const [reviewDetails, setReviewDetails] =
     useState<ReviewDetailsWithoutAlcoholInfo | null>(null);
+  const [modalType, setModalType] = useState<'copy' | 'login' | null>(null);
+
+  const handleLogin = () => {
+    setModalType('login');
+    handleModal();
+  };
+
+  const handleShare = () => {
+    setModalType('copy');
+    handleModal();
+  };
 
   useEffect(() => {
     async function fetchReviewDetails() {
@@ -44,55 +59,64 @@ export default function ReviewDetail() {
   return (
     <>
       {alcoholInfo && reviewDetails ? (
-        <NavLayout>
-          <div className="relative pb-5">
-            {alcoholInfo.imageUrl && (
-              <div
-                className={`absolute w-full h-full  bg-cover bg-center`}
-                style={{
-                  backgroundImage: `url(${alcoholInfo.imageUrl})`,
-                }}
-              />
-            )}
-            <div className="absolute w-full h-full bg-mainCoral bg-opacity-90" />
-            <SubHeader bgColor="bg-mainCoral/10">
-              <SubHeader.Left
-                onClick={() => {
-                  router.back();
-                }}
-              >
-                <Image
-                  src="/icon/arrow-left-white.svg"
-                  alt="arrowIcon"
-                  width={23}
-                  height={23}
+        <>
+          <NavLayout>
+            <div className="relative pb-5">
+              {alcoholInfo.imageUrl && (
+                <div
+                  className={`absolute w-full h-full  bg-cover bg-center`}
+                  style={{
+                    backgroundImage: `url(${alcoholInfo.imageUrl})`,
+                  }}
                 />
-              </SubHeader.Left>
-              <SubHeader.Center textColor="text-white">
-                리뷰 상세보기
-              </SubHeader.Center>
-              <SubHeader.Right
-                onClick={() => {
-                  shareOrCopy(
-                    `${process.env.NEXT_PUBLIC_BOTTLE_NOTE_URL}/review/${reviewId}`,
-                    `${alcoholInfo.korName} 리뷰`,
-                    `${alcoholInfo.korName} 리뷰 상세보기`,
-                  );
-                }}
-              >
-                <Image
-                  src="/icon/externallink-outlined-white.svg"
-                  alt="linkIcon"
-                  width={23}
-                  height={23}
-                />
-              </SubHeader.Right>
-            </SubHeader>
-            {alcoholInfo && <AlcoholInfo data={alcoholInfo} />}
-          </div>
-          <ReviewDetails data={reviewDetails} />
-          {/* 댓글 api 변경으로 댓글 구현 시 수정 예정 */}
-          {/* {data?.reviewReplyList ? (
+              )}
+              <div className="absolute w-full h-full bg-mainCoral bg-opacity-90" />
+              <SubHeader bgColor="bg-mainCoral/10">
+                <SubHeader.Left
+                  onClick={() => {
+                    router.back();
+                  }}
+                >
+                  <Image
+                    src="/icon/arrow-left-white.svg"
+                    alt="arrowIcon"
+                    width={23}
+                    height={23}
+                  />
+                </SubHeader.Left>
+                <SubHeader.Center textColor="text-white">
+                  리뷰 상세보기
+                </SubHeader.Center>
+                <SubHeader.Right
+                  onClick={() => {
+                    setModalType('copy');
+                    shareOrCopy(
+                      `${process.env.NEXT_PUBLIC_BOTTLE_NOTE_URL}/review/${reviewId}`,
+                      handleModal,
+                      `${alcoholInfo.korName} 리뷰`,
+                      `${alcoholInfo.korName} 리뷰 상세보기`,
+                    );
+                  }}
+                >
+                  <Image
+                    src="/icon/externallink-outlined-white.svg"
+                    alt="linkIcon"
+                    width={23}
+                    height={23}
+                  />
+                </SubHeader.Right>
+              </SubHeader>
+              {alcoholInfo && (
+                <AlcoholInfo data={alcoholInfo} handleLogin={handleLogin} />
+              )}
+            </div>
+            <ReviewDetails
+              data={reviewDetails}
+              handleShare={handleShare}
+              handleLogin={handleLogin}
+            />
+            {/* 댓글 api 변경으로 댓글 구현 시 수정 예정 */}
+            {/* {data?.reviewReplyList ? (
             <>
               <div className="h-4 bg-sectionWhite" />
               <section className="mx-5 py-5 space-y-4">
@@ -108,13 +132,23 @@ export default function ReviewDetail() {
             </>
           ) : (
             <> */}
-          <div className="h-4 bg-sectionWhite" />
-          <section className="py-5">
-            <EmptyView text="아직 댓글이 없어요!" />
-          </section>
-          {/* </>
+            <div className="h-4 bg-sectionWhite" />
+            <section className="py-5">
+              <EmptyView text="아직 댓글이 없어요!" />
+            </section>
+            {/* </>
           )} */}
-        </NavLayout>
+          </NavLayout>
+          {showModal && modalType === 'copy' && (
+            <Modal
+              mainText={'해당 페이지 링크를 복사했습니다.'}
+              subText={'친구에게 공유하러 가볼까요?'}
+            />
+          )}
+          {showModal && modalType === 'login' && (
+            <LoginModal handleClose={handleModal} />
+          )}
+        </>
       ) : (
         <Loading />
       )}

--- a/src/app/(primary)/review/[id]/page.tsx
+++ b/src/app/(primary)/review/[id]/page.tsx
@@ -140,10 +140,10 @@ export default function ReviewDetail() {
           )} */}
           </NavLayout>
           {showModal && modalType === 'copy' && (
-            <Modal
-              mainText={'해당 페이지 링크를 복사했습니다.'}
-              subText={'친구에게 공유하러 가볼까요?'}
-            />
+            <Modal>
+              <p className="modal-mainText">해당 페이지 링크를 복사했습니다.</p>
+              <p className="modal-subText">친구에게 공유하러 가볼까요?</p>
+            </Modal>
           )}
           {showModal && modalType === 'login' && (
             <LoginModal handleClose={handleModal} />

--- a/src/app/(primary)/review/_components/AlcoholInfo.tsx
+++ b/src/app/(primary)/review/_components/AlcoholInfo.tsx
@@ -84,7 +84,8 @@ function AlcoholInfo({ data }: Props) {
               <div className="border-[0.5px] border-white" />
               <PickBtn
                 isPicked={isPicked}
-                setIsPicked={setIsPicked}
+                handleUpdatePicked={() => setIsPicked(!isPicked)}
+                handleRollback={() => setIsPicked(originalIsPicked)}
                 pickBtnName="찜하기"
                 alcoholId={data.alcoholId}
               />

--- a/src/app/(primary)/review/_components/SelectFlavor.tsx
+++ b/src/app/(primary)/review/_components/SelectFlavor.tsx
@@ -1,36 +1,41 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 
 interface Props {
   tags: string[];
   setTags: React.Dispatch<React.SetStateAction<string[]>>;
+  setIsAdding: React.Dispatch<React.SetStateAction<boolean>>;
+  updateAlert: (content: string | string[]) => void;
 }
 
 function validateText(text: string) {
-  const regex = /[\d]|[^a-zA-Z가-힣]/;
-
-  if (regex.test(text)) {
-    return false;
-  }
-  return true;
+  const regex = /^[a-zA-Z가-힣]+$/;
+  return regex.test(text);
 }
 
-export default function SelectFlavor({ tags, setTags }: Props) {
+export default function SelectFlavor({
+  tags,
+  setTags,
+  setIsAdding,
+  updateAlert,
+}: Props) {
   const [value, setValue] = useState<string>('');
 
   const handleAddTag = () => {
     if (value.length === 0) {
-      alert('추가하고 싶은 태그를 작성해주세요:)');
+      updateAlert('추가하고 싶은 태그를 작성해주세요:)');
     } else if (tags.includes(value)) {
-      alert('이미 동일한 태그가 있습니다.');
+      updateAlert('이미 동일한 태그가 있습니다.');
     } else if (!validateText(value)) {
-      alert('태그에 숫자와 특수문자는 추가할 수 없습니다.');
+      updateAlert(['태그에 숫자와 특수문자는', '추가할 수 없습니다.']);
     } else {
       const newTags = [...tags, value];
       setTags(newTags);
       setValue('');
+      setIsAdding(false);
+      return;
     }
   };
 
@@ -62,9 +67,10 @@ export default function SelectFlavor({ tags, setTags }: Props) {
             placeholder="예) 반건조 된 건자두"
             value={value}
             maxLength={12}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setValue(e.target.value)
-            }
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setIsAdding(true);
+              setValue(e.target.value);
+            }}
           />
           <button
             className={`text-10 py-[0.13rem] px-2 rounded border  w-16 ${tags.length !== 10 ? 'border-subCoral text-subCoral' : 'border-[#BFBFBF] text-[#BFBFBF]'}`}

--- a/src/app/(primary)/review/_components/SelectFlavor.tsx
+++ b/src/app/(primary)/review/_components/SelectFlavor.tsx
@@ -29,7 +29,7 @@ export default function SelectFlavor({
     } else if (tags.includes(value)) {
       updateAlert('이미 동일한 태그가 있습니다.');
     } else if (!validateText(value)) {
-      updateAlert(['태그에 숫자와 특수문자는', '추가할 수 없습니다.']);
+      updateAlert('태그에 숫자와 특수문자는 추가할 수 없습니다.');
     } else {
       const newTags = [...tags, value];
       setTags(newTags);

--- a/src/app/(primary)/review/_components/TagsForm.tsx
+++ b/src/app/(primary)/review/_components/TagsForm.tsx
@@ -21,13 +21,13 @@ export default function TagsForm({ korName }: Props) {
   const [tags, setTags] = useState<string[]>([]);
   const [isAdding, setIsAdding] = useState(false);
   const [modalContent, setModalContent] = useState<string | string[]>('');
-  const [modalType, setModalType] = useState<'alert' | 'confirm' | null>(null);
+  const [modalType, setModalType] = useState<'back' | 'notice' | null>(null);
 
   const { setValue, watch } = useFormContext();
 
   const updateAlert = (content: string | string[]) => {
     setModalContent(content);
-    setModalType('alert');
+    setModalType('notice');
     handleModal();
   };
 
@@ -87,7 +87,7 @@ export default function TagsForm({ korName }: Props) {
             <SubHeader.Left
               onClick={() => {
                 if (isAdding) {
-                  setModalType('confirm');
+                  setModalType('back');
                   handleModal();
                 } else {
                   setTagModal(false);
@@ -114,14 +114,9 @@ export default function TagsForm({ korName }: Props) {
           />
         </PageModal>
       )}
-      {showModal && modalType === 'confirm' && (
+      {showModal && modalType === 'back' && (
         <Modal
           type="confirm"
-          mainText={[
-            '입력중인 테이스팅 태그가 있습니다.',
-            '정말 나가시겠습니까?',
-          ]}
-          subText="태그가 완성되지않으면 없어져요!"
           confirmBtnName="아니요"
           cancelBtnName="예"
           handleCancel={() => {
@@ -129,10 +124,21 @@ export default function TagsForm({ korName }: Props) {
             setTagModal(false);
             setValue('flavor_tags', tags);
           }}
-        />
+        >
+          <article>
+            <p className="modal-mainText">입력중인 테이스팅 태그가 있습니다.</p>
+            <p className="modal-mainText">정말 나가시겠습니까?</p>
+
+            <p className="modal-subText">태그가 완성되지않으면 없어져요!</p>
+          </article>
+        </Modal>
       )}
-      {showModal && modalContent !== '' && modalType === 'alert' && (
-        <Modal mainText={modalContent} />
+      {showModal && modalContent !== '' && modalType === 'notice' && (
+        <Modal>
+          <article>
+            <p className="modal-mainText">{modalContent}</p>
+          </article>
+        </Modal>
       )}
     </>
   );

--- a/src/app/(primary)/review/modify/page.tsx
+++ b/src/app/(primary)/review/modify/page.tsx
@@ -213,10 +213,9 @@ function ReviewModify() {
           <Button onClick={handleSubmit(onSave)} btnName="리뷰 수정" />
         </article>
       </FormProvider>
-      {showModal && (
+      {showModal && modalType && ['cancel', 'save'].includes(modalType) && (
         <Modal
           type={modalType === 'save' ? 'alert' : 'confirm'}
-          mainText={modalContent}
           confirmBtnName={modalType === 'cancel' ? '아니요' : ''}
           cancelBtnName={modalType === 'cancel' ? '예' : ''}
           handleCancel={() => {
@@ -232,7 +231,11 @@ function ReviewModify() {
             }
             setModalType(null);
           }}
-        />
+        >
+          <article>
+            <p className="modal-mainText">{modalContent}</p>
+          </article>
+        </Modal>
       )}
     </>
   );

--- a/src/app/(primary)/review/modify/page.tsx
+++ b/src/app/(primary)/review/modify/page.tsx
@@ -16,14 +16,19 @@ import { ReviewApi } from '@/app/api/ReviewApi';
 import { uploadImages } from '@/utils/S3Upload';
 import { RateApi } from '@/app/api/RateApi';
 import { Button } from '@/components/Button';
+import useModalStore from '@/store/modalStore';
+import Modal from '@/components/Modal';
 
 function ReviewModify() {
   const router = useRouter();
+  const { showModal, handleModal } = useModalStore();
   const searchParams = useSearchParams();
   const reviewId = searchParams.get('reviewId');
   const [alcoholId, setAlcoholId] = useState<string>('');
   const [alcoholData, setAlcoholData] = useState<AlcoholDetails>();
   const [initialRating, setInitialRating] = useState<number>(0);
+  const [modalType, setModalType] = useState<'save' | 'cancel' | null>(null);
+  const [modalContent, setModalContent] = useState<string | string[]>('');
 
   const schema = yup.object({
     review: yup.string().required('리뷰 내용을 작성해주세요.'),
@@ -45,8 +50,6 @@ function ReviewModify() {
     reset,
     formState: { isDirty, errors }, // 적용 필요
   } = formMethods;
-
-  // console.log('errors', errors);
 
   const onSave = (data: FormValues) => {
     if (data.images !== null) {
@@ -99,22 +102,24 @@ function ReviewModify() {
       },
     };
 
-    let ratingResult;
-    let reviewResult;
-    // 별점만 수정한 경우에 대한 조건 추가 필요
+    let ratingResult = null;
+    let reviewResult = null;
     if (initialRating !== data.rating) {
       ratingResult = await RateApi.postRating(ratingParams);
     }
     if (reviewId) {
       reviewResult = await ReviewApi.modifyReview(reviewId, reviewParams);
     }
-    if (initialRating !== data.rating && ratingResult && reviewResult) {
-      router.push(`/review/${reviewResult.reviewId}`);
-    } else if (reviewResult) {
-      // 대응에 대한 논의 필요
-      // alert('별점은 등록되지 않았습니다.');
-      router.push(`/review/${reviewResult.reviewId}`);
-    } else if (initialRating !== data.rating && ratingResult) {
+
+    if (
+      (initialRating !== data.rating && ratingResult && reviewResult) ||
+      (initialRating === data.rating && reviewResult) ||
+      (initialRating !== data.rating && reviewResult && !ratingResult)
+    ) {
+      setModalContent('성공적으로 수정했습니다 👍');
+      setModalType('save');
+      handleModal();
+    } else if (initialRating !== data.rating && ratingResult && !reviewResult) {
       // alert('리뷰는 등록되지 않았습니다.');
       router.back();
     }
@@ -156,10 +161,11 @@ function ReviewModify() {
     }
   }, [alcoholId]);
 
-  // 추후 Modal로 수정 예정
   useEffect(() => {
     if (errors.review?.message) {
-      alert(errors.review?.message);
+      setModalContent(errors.review?.message);
+      handleModal();
+      setModalType('save');
     }
   }, [errors]);
 
@@ -177,7 +183,16 @@ function ReviewModify() {
           <SubHeader bgColor="bg-mainCoral/10">
             <SubHeader.Left
               onClick={() => {
-                router.back();
+                if (isDirty) {
+                  setModalType('cancel');
+                  setModalContent([
+                    '수정 중인 내용이 사라집니다.',
+                    '정말 뒤로 가시겠습니까?',
+                  ]);
+                  handleModal();
+                } else {
+                  router.back();
+                }
               }}
             >
               <Image
@@ -198,6 +213,27 @@ function ReviewModify() {
           <Button onClick={handleSubmit(onSave)} btnName="리뷰 수정" />
         </article>
       </FormProvider>
+      {showModal && (
+        <Modal
+          type={modalType === 'save' ? 'alert' : 'confirm'}
+          mainText={modalContent}
+          confirmBtnName={modalType === 'cancel' ? '아니요' : ''}
+          cancelBtnName={modalType === 'cancel' ? '예' : ''}
+          handleCancel={() => {
+            handleModal();
+            if (modalType === 'cancel' && isDirty) {
+              router.back();
+            }
+          }}
+          handleConfirm={() => {
+            handleModal();
+            if (modalType === 'save') {
+              !errors.review && router.push(`/review/${reviewId}`);
+            }
+            setModalType(null);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/src/app/(primary)/review/register/page.tsx
+++ b/src/app/(primary)/review/register/page.tsx
@@ -27,7 +27,7 @@ function ReviewRegister() {
   const [alcoholData, setAlcoholData] = useState<AlcoholDetails>();
   const [initialRating, setInitialRating] = useState<number>(0);
   const [modalType, setModalType] = useState<'save' | 'cancel' | null>(null);
-  const [modalContent, setModalContent] = useState<string | string[]>('');
+  const [modalContent, setModalContent] = useState<string>('');
   const [modalSubContent, setModalSubContent] = useState<string>('');
   const [reviewId, setReviewId] = useState<number | null>(null);
 
@@ -180,10 +180,9 @@ function ReviewRegister() {
               onClick={() => {
                 if (isDirty) {
                   setModalType('cancel');
-                  setModalContent([
-                    '작성 중인 내용이 사라집니다.',
-                    '정말 뒤로 가시겠습니까?',
-                  ]);
+                  setModalContent(
+                    '작성 중인 내용이 사라집니다.\n정말 뒤로 가시겠습니까?',
+                  );
                   handleModal();
                 } else {
                   router.back();
@@ -226,12 +225,9 @@ function ReviewRegister() {
               router.push(`/review/${reviewId}`);
             }
           }}
-        >
-          <article>
-            <p className="modal-mainText">{modalContent}</p>
-            <p className="modal-subText">{modalSubContent ?? ''}</p>
-          </article>
-        </Modal>
+          mainText={modalContent}
+          subText={modalSubContent}
+        />
       )}
     </>
   );

--- a/src/app/(primary)/review/register/page.tsx
+++ b/src/app/(primary)/review/register/page.tsx
@@ -208,11 +208,9 @@ function ReviewRegister() {
           <Button onClick={handleSubmit(onSave)} btnName="리뷰 등록" />
         </article>
       </FormProvider>
-      {showModal && (
+      {showModal && modalType && ['cancel', 'save'].includes(modalType) && (
         <Modal
           type={modalType === 'cancel' ? 'confirm' : 'alert'}
-          mainText={modalContent}
-          subText={modalSubContent ?? ''}
           confirmBtnName={modalType === 'cancel' ? '아니요' : ''}
           cancelBtnName={modalType === 'cancel' ? '예' : ''}
           handleCancel={() => {
@@ -228,7 +226,12 @@ function ReviewRegister() {
               router.push(`/review/${reviewId}`);
             }
           }}
-        />
+        >
+          <article>
+            <p className="modal-mainText">{modalContent}</p>
+            <p className="modal-subText">{modalSubContent ?? ''}</p>
+          </article>
+        </Modal>
       )}
     </>
   );

--- a/src/app/(primary)/review/register/page.tsx
+++ b/src/app/(primary)/review/register/page.tsx
@@ -16,13 +16,20 @@ import { ReviewApi } from '@/app/api/ReviewApi';
 import { RateApi } from '@/app/api/RateApi';
 import { uploadImages } from '@/utils/S3Upload';
 import { Button } from '@/components/Button';
+import useModalStore from '@/store/modalStore';
+import Modal from '@/components/Modal';
 
 function ReviewRegister() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { showModal, handleModal } = useModalStore();
   const alcoholId = searchParams.get('alcoholId') || '';
   const [alcoholData, setAlcoholData] = useState<AlcoholDetails>();
   const [initialRating, setInitialRating] = useState<number>(0);
+  const [modalType, setModalType] = useState<'save' | 'cancel' | null>(null);
+  const [modalContent, setModalContent] = useState<string | string[]>('');
+  const [modalSubContent, setModalSubContent] = useState<string>('');
+  const [reviewId, setReviewId] = useState<number | null>(null);
 
   const schema = yup.object({
     review: yup.string().required('리뷰 내용을 작성해주세요.'),
@@ -40,12 +47,9 @@ function ReviewRegister() {
 
   const {
     handleSubmit,
-    setValue,
     reset,
-    formState: { isDirty, errors }, // 적용 필요
+    formState: { isDirty, errors },
   } = formMethods;
-
-  // console.log('errors', errors);
 
   const onSave = (data: FormValues) => {
     // console.log('data1', data);
@@ -94,19 +98,28 @@ function ReviewRegister() {
       },
     };
 
-    let ratingResult;
+    let ratingResult = null;
     if (initialRating !== data.rating) {
       ratingResult = await RateApi.postRating(ratingParams);
     }
     const reviewResult = await ReviewApi.registerReview(reviewParams);
 
     // error에 대해 추후 보완 예정
-    if (initialRating !== data.rating && ratingResult && reviewResult) {
-      router.push(`/review/${reviewResult.id}`);
-    } else if (reviewResult) {
-      // alert('별점은 등록되지 않았습니다.');
-      router.push(`/review/${reviewResult.id}`);
-    } else if (initialRating !== data.rating && ratingResult) {
+    if (
+      (initialRating !== data.rating && ratingResult && reviewResult) ||
+      (initialRating === data.rating && reviewResult) ||
+      (initialRating !== data.rating && reviewResult && !ratingResult)
+    ) {
+      setReviewId(reviewResult.id);
+      const text =
+        initialRating !== data.rating && !ratingResult
+          ? '❗️별점 등록에는 실패했습니다. 다시 시도해주세요.'
+          : '여정에 한발 더 가까워지셨어요!';
+      setModalContent('작성을 완료했습니다 👍');
+      setModalSubContent(text);
+      setModalType('save');
+      handleModal();
+    } else if (initialRating !== data.rating && ratingResult && !reviewResult) {
       // alert('리뷰는 등록되지 않았습니다.');
       router.back();
     }
@@ -143,10 +156,11 @@ function ReviewRegister() {
     }
   }, [alcoholId]);
 
-  // 추후 Modal로 수정 예정
   useEffect(() => {
     if (errors.review?.message) {
-      alert(errors.review?.message);
+      setModalContent(errors.review?.message);
+      handleModal();
+      setModalType('save');
     }
   }, [errors]);
 
@@ -164,7 +178,16 @@ function ReviewRegister() {
           <SubHeader bgColor="bg-mainCoral/10">
             <SubHeader.Left
               onClick={() => {
-                router.back();
+                if (isDirty) {
+                  setModalType('cancel');
+                  setModalContent([
+                    '작성 중인 내용이 사라집니다.',
+                    '정말 뒤로 가시겠습니까?',
+                  ]);
+                  handleModal();
+                } else {
+                  router.back();
+                }
               }}
             >
               <Image
@@ -185,6 +208,28 @@ function ReviewRegister() {
           <Button onClick={handleSubmit(onSave)} btnName="리뷰 등록" />
         </article>
       </FormProvider>
+      {showModal && (
+        <Modal
+          type={modalType === 'cancel' ? 'confirm' : 'alert'}
+          mainText={modalContent}
+          subText={modalSubContent ?? ''}
+          confirmBtnName={modalType === 'cancel' ? '아니요' : ''}
+          cancelBtnName={modalType === 'cancel' ? '예' : ''}
+          handleCancel={() => {
+            handleModal();
+            if (modalType === 'cancel' && isDirty) {
+              router.back();
+            }
+          }}
+          handleConfirm={() => {
+            handleModal();
+            setModalType(null);
+            if (modalType === 'save' && reviewId) {
+              router.push(`/review/${reviewId}`);
+            }
+          }}
+        />
+      )}
     </>
   );
 }

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -19,6 +19,7 @@ import EmptyView from '@/app/(primary)/_components/EmptyView';
 import LoginModal from '@/app/(primary)/_components/LoginModal';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
 import { AlcoholsApi } from '@/app/api/AlcholsApi';
+import useModalStore from '@/store/modalStore';
 
 type Details = {
   title: string;
@@ -30,14 +31,10 @@ function SearchCategory() {
   const params = useParams();
   const { data: session } = useSession();
   const alcoholId = params?.id;
+  const { showModal, handleModal } = useModalStore();
   const [data, setData] = useState<AlcoholDetails | null>(null);
   const [details, setDetails] = useState<Details[]>([]);
-  const [isLoginModalShow, setIsLoginModalShow] = useState<boolean>(false);
   const [isPicked, setIsPicked] = useState<boolean>(false);
-
-  const handleLoginModalShow = () => {
-    setIsLoginModalShow((prev) => !prev);
-  };
 
   const fetchAlcoholDetails = async (id: string) => {
     const result = await AlcoholsApi.getAlcoholDetails(id);
@@ -153,7 +150,7 @@ function SearchCategory() {
                               `/review/register?alcoholId=${alcoholId}`,
                             );
                           } else {
-                            setIsLoginModalShow(true);
+                            handleModal();
                           }
                         }}
                       >
@@ -173,6 +170,7 @@ function SearchCategory() {
                         handleRollback={() =>
                           setIsPicked(data?.alcohols?.isPicked)
                         }
+                        handleNotLogin={handleModal}
                         pickBtnName="찜하기"
                         alcoholId={Number(alcoholId)}
                         size={16}
@@ -298,7 +296,7 @@ function SearchCategory() {
           </>
         )}
       </NavLayout>
-      {isLoginModalShow && <LoginModal handleClose={handleLoginModalShow} />}
+      {showModal && <LoginModal handleClose={handleModal} />}
     </>
   );
 }

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -169,7 +169,10 @@ function SearchCategory() {
                       <div className="border-[0.5px] border-white my-[0.1rem]" />
                       <PickBtn
                         isPicked={isPicked}
-                        setIsPicked={setIsPicked}
+                        handleUpdatePicked={() => setIsPicked(!isPicked)}
+                        handleRollback={() =>
+                          setIsPicked(data?.alcohols?.isPicked)
+                        }
                         pickBtnName="찜하기"
                         alcoholId={Number(alcoholId)}
                         size={16}

--- a/src/app/api/ReviewApi.ts
+++ b/src/app/api/ReviewApi.ts
@@ -30,8 +30,25 @@ export const ReviewApi = {
       throw new Error('Failed to fetch data');
     }
 
-    const { data }: ApiResponse<ReviewDetailsApi> = await response.json();
-    return data;
+    const result: ApiResponse<{
+      alcoholInfo: any;
+      reviewResponse: any;
+      reviewImageList: any[];
+    }> = await response.json();
+
+    const formattedResult: ApiResponse<ReviewDetailsApi> = {
+      ...result,
+      data: {
+        ...result.data,
+        alcoholInfo: {
+          ...result.data.alcoholInfo,
+          engCategory: result.data.alcoholInfo.engCategoryName,
+          korCategory: result.data.alcoholInfo.korCategoryName,
+        },
+      },
+    };
+
+    return formattedResult.data;
   },
 
   async registerReview(params: ReviewQueryParams) {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -53,7 +53,7 @@ export function Button({
   type = 'button',
   onClick,
   btnStyles = 'bg-subCoral',
-  btnTextStyles = 'text-white font-bold text-base',
+  btnTextStyles = 'text-white font-bold text-15',
   disabled = false,
 }: ButtonProps) {
   return (

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,3 @@
-'use client';
-
-import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import BackDrop from '@/components/BackDrop';
 import useModalStore from '@/store/modalStore';
@@ -8,8 +5,7 @@ import { Button, DualButton } from '@/components/Button';
 
 interface Props {
   type?: 'alert' | 'confirm';
-  mainText: string | string[]; // 라인 별로 나누어 출력
-  subText?: string;
+  children: React.ReactNode;
   alertBtnName?: string;
   handleCancel?: () => void;
   handleConfirm?: () => void;
@@ -19,8 +15,7 @@ interface Props {
 
 function Modal({
   type = 'alert',
-  mainText,
-  subText,
+  children,
   handleCancel,
   handleConfirm,
   alertBtnName = '확인',
@@ -28,7 +23,6 @@ function Modal({
   cancelBtnName,
 }: Props) {
   const { showModal, handleModal } = useModalStore();
-  const [mainTextArray, setMainTextArray] = useState<string[]>([]);
 
   const handleOkayClick = () => {
     if (handleConfirm) handleConfirm();
@@ -40,51 +34,32 @@ function Modal({
     else handleModal();
   };
 
-  useEffect(() => {
-    if (mainText) {
-      setMainTextArray(Array.isArray(mainText) ? mainText : [mainText]);
-    }
-  }, [mainText]);
-
   return (
-    <>
-      {mainTextArray.length !== 0 && (
-        <BackDrop isShow={showModal}>
-          <div className="w-full h-full flex flex-col justify-center items-center px-4 gap-3">
-            <section className="relative w-full min-h-52 pt-16 pb-4 bg-white rounded-xl text-center flex flex-col items-center space-y-4 px-4">
-              <article className="absolute top-[-10px]">
-                <Image
-                  src="/icon/logo-subcoral.svg"
-                  alt="bottle_logo"
-                  width={40}
-                  height={55}
-                />
-              </article>
-              <article>
-                {mainTextArray.map((line: string, index: number) => (
-                  <p key={index} className="text-20 text-subCoral font-medium">
-                    {line}
-                  </p>
-                ))}
-                {subText && (
-                  <p className="text-15 text-mainDarkGray">{subText}</p>
-                )}
-              </article>
-              {type === 'alert' ? (
-                <Button btnName={alertBtnName} onClick={handleOkayClick} />
-              ) : (
-                <DualButton
-                  onClickCancel={handleCancelClick}
-                  onClickOkay={handleOkayClick}
-                  okayBtnName={confirmBtnName}
-                  cancelBtnName={cancelBtnName}
-                />
-              )}
-            </section>
-          </div>
-        </BackDrop>
-      )}
-    </>
+    <BackDrop isShow={showModal}>
+      <div className="w-full h-full flex flex-col justify-center items-center px-4 gap-3">
+        <section className="relative w-full min-h-52 pt-16 pb-4 bg-white rounded-xl text-center flex flex-col items-center space-y-4 px-4">
+          <article className="absolute top-[-10px]">
+            <Image
+              src="/icon/logo-subcoral.svg"
+              alt="bottle_logo"
+              width={40}
+              height={55}
+            />
+          </article>
+          {children}
+          {type === 'alert' ? (
+            <Button btnName={alertBtnName} onClick={handleOkayClick} />
+          ) : (
+            <DualButton
+              onClickCancel={handleCancelClick}
+              onClickOkay={handleOkayClick}
+              okayBtnName={confirmBtnName}
+              cancelBtnName={cancelBtnName}
+            />
+          )}
+        </section>
+      </div>
+    </BackDrop>
   );
 }
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -5,12 +5,14 @@ import { Button, DualButton } from '@/components/Button';
 
 interface Props {
   type?: 'alert' | 'confirm';
-  children: React.ReactNode;
+  children?: React.ReactNode;
   alertBtnName?: string;
   handleCancel?: () => void;
   handleConfirm?: () => void;
   confirmBtnName?: string;
   cancelBtnName?: string;
+  mainText?: string;
+  subText?: string;
 }
 
 function Modal({
@@ -21,6 +23,8 @@ function Modal({
   alertBtnName = '확인',
   confirmBtnName,
   cancelBtnName,
+  mainText,
+  subText,
 }: Props) {
   const { showModal, handleModal } = useModalStore();
 
@@ -47,6 +51,8 @@ function Modal({
             />
           </article>
           {children}
+          <p className="modal-mainText">{mainText}</p>
+          <p className="modal-subText">{subText}</p>
           {type === 'alert' ? (
             <Button btnName={alertBtnName} onClick={handleOkayClick} />
           ) : (

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,8 +1,91 @@
-export interface Props {
-  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  children: React.ReactNode;
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+import BackDrop from '@/components/BackDrop';
+import useModalStore from '@/store/modalStore';
+import { Button, DualButton } from '@/components/Button';
+
+interface Props {
+  type?: 'alert' | 'confirm';
+  mainText: string | string[]; // 라인 별로 나누어 출력
+  subText?: string;
+  alertBtnName?: string;
+  handleCancel?: () => void;
+  handleConfirm?: () => void;
+  confirmBtnName?: string;
+  cancelBtnName?: string;
 }
 
-export default function FullModal({ setModalOpen, children }: Props) {
-  return <main className="z-10 fixed w-full inset-0 bg-white">{children}</main>;
+function Modal({
+  type = 'alert',
+  mainText,
+  subText,
+  handleCancel,
+  handleConfirm,
+  alertBtnName = '확인',
+  confirmBtnName,
+  cancelBtnName,
+}: Props) {
+  const { showModal, handleModal } = useModalStore();
+  const [mainTextArray, setMainTextArray] = useState<string[]>([]);
+
+  const handleOkayClick = () => {
+    if (handleConfirm) handleConfirm();
+    else handleModal();
+  };
+
+  const handleCancelClick = () => {
+    if (handleCancel) handleCancel();
+    else handleModal();
+  };
+
+  useEffect(() => {
+    if (mainText) {
+      setMainTextArray(Array.isArray(mainText) ? mainText : [mainText]);
+    }
+  }, [mainText]);
+
+  return (
+    <>
+      {mainTextArray.length !== 0 && (
+        <BackDrop isShow={showModal}>
+          <div className="w-full h-full flex flex-col justify-center items-center px-4 gap-3">
+            <section className="relative w-full min-h-52 pt-16 pb-4 bg-white rounded-xl text-center flex flex-col items-center space-y-4 px-4">
+              <article className="absolute top-[-10px]">
+                <Image
+                  src="/icon/logo-subcoral.svg"
+                  alt="bottle_logo"
+                  width={40}
+                  height={55}
+                />
+              </article>
+              <article>
+                {mainTextArray.map((line: string, index: number) => (
+                  <p key={index} className="text-20 text-subCoral font-medium">
+                    {line}
+                  </p>
+                ))}
+                {subText && (
+                  <p className="text-15 text-mainDarkGray">{subText}</p>
+                )}
+              </article>
+              {type === 'alert' ? (
+                <Button btnName={alertBtnName} onClick={handleOkayClick} />
+              ) : (
+                <DualButton
+                  onClickCancel={handleCancelClick}
+                  onClickOkay={handleOkayClick}
+                  okayBtnName={confirmBtnName}
+                  cancelBtnName={cancelBtnName}
+                />
+              )}
+            </section>
+          </div>
+        </BackDrop>
+      )}
+    </>
+  );
 }
+
+export default Modal;

--- a/src/components/PageModal.tsx
+++ b/src/components/PageModal.tsx
@@ -1,0 +1,7 @@
+export interface Props {
+  children: React.ReactNode;
+}
+
+export default function PageModal({ children }: Props) {
+  return <main className="z-10 fixed w-full inset-0 bg-white">{children}</main>;
+}

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface ModalStore {
+  showModal: boolean;
+  handleModal: () => void;
+}
+
+const useModalStore = create<ModalStore>((set) => ({
+  showModal: false,
+  handleModal: () => set((state) => ({ showModal: !state.showModal })),
+}));
+
+export default useModalStore;

--- a/src/style/globals.css
+++ b/src/style/globals.css
@@ -34,11 +34,11 @@
   }
 
   .modal-mainText {
-    @apply text-15 text-subCoral font-medium;
+    @apply text-15 text-subCoral font-medium whitespace-pre-wrap;
   }
 
   .modal-subText {
-    @apply text-13 text-mainDarkGray;
+    @apply text-13 text-mainDarkGray whitespace-pre-wrap;
   }
 }
 

--- a/src/style/globals.css
+++ b/src/style/globals.css
@@ -32,6 +32,14 @@
   .line-border {
     @apply border-t border-mainGray/30 my-3;
   }
+
+  .modal-mainText {
+    @apply text-15 text-subCoral font-medium;
+  }
+
+  .modal-subText {
+    @apply text-13 text-mainDarkGray;
+  }
 }
 
 @layer utilities {

--- a/src/types/Review.ts
+++ b/src/types/Review.ts
@@ -40,8 +40,8 @@ export interface AlcoholInfo {
   alcoholId: number;
   korName: string;
   engName: string;
-  korCategoryName: string;
-  engCategoryName: string;
+  korCategory: string;
+  engCategory: string;
   imageUrl: string;
   isPicked: boolean;
 }
@@ -71,12 +71,10 @@ export interface ReviewDetailsApi {
     isBestReview: boolean;
     reviewTastingTag: string[];
   };
-  reviewImageList: [
-    {
-      order: number;
-      viewUrl: string;
-    },
-  ];
+  reviewImageList: {
+    order: number;
+    viewUrl: string;
+  }[];
   // 최근 변경된 사항으로 댓글 구현 시 수정 예정
   // reviewReplyList: [
   //   {

--- a/src/utils/shareOrCopy.ts
+++ b/src/utils/shareOrCopy.ts
@@ -1,8 +1,13 @@
-export function shareOrCopy(url: string, title?: string, text?: string) {
+export function shareOrCopy(
+  url: string,
+  handleModal?: () => void,
+  title?: string,
+  text?: string,
+) {
   if (isMobileEnvironment()) {
     shareOnMobile(url, title, text);
   } else {
-    copyUrlToClipboard(url);
+    copyUrlToClipboard(url, handleModal);
   }
 
   function isMobileEnvironment() {
@@ -13,7 +18,6 @@ export function shareOrCopy(url: string, title?: string, text?: string) {
   }
 
   async function shareOnMobile(url: string, title?: string, text?: string) {
-    alert(window.navigator.share);
     if (navigator.share) {
       await navigator
         .share({
@@ -28,10 +32,12 @@ export function shareOrCopy(url: string, title?: string, text?: string) {
     }
   }
 
-  async function copyUrlToClipboard(url: string) {
+  async function copyUrlToClipboard(url: string, handleModal?: () => void) {
     await navigator.clipboard
       .writeText(url)
-      .then(() => alert('URL 복사 성공'))
+      .then(() => {
+        handleModal && handleModal();
+      })
       .catch((error) => console.log('URL 복사 실패', error));
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5161,6 +5161,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5375,3 +5380,10 @@ yup@^1.4.0:
     tiny-case "^1.0.3"
     toposort "^2.0.2"
     type-fest "^2.19.0"
+
+zustand@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.4.tgz#63abdd81edfb190bc61e0bbae045cc4d52158a05"
+  integrity sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
### PR 제목 (Title)

* [#98] 공통 Modal 기능 구현 및 review에 공통 modal 적용

### 변경 사항 (Changes)

 - [x] 리뷰 API korCategoryName, engCategoryName을 korCategory, engCategory로 변경
 - [x] 찜하기, 좋아요 컴포넌트 setter 방식 함수로 변경
 - [x] zustand 라이브러리 설치 및 store 생성
 - [x] 공통 Modal confirm, alert 구현
 - [x] review에 공통 modal 적용

### 테스트 방법 (Test Procedure)

1. home에서 알콜 화면 클릭해서 이동 후 리뷰 작성하기에서 작성 중간에 뒤로가기 버튼 등 눌러서 확인 가능
2. 로그인 전, 리뷰 내에 로그인 필요한 버튼 누르면 확인 가능 

### 참고 사항 (Additional Information)

* 찜하기, 좋아요 컴포넌트에 업데이트 해주는 부분 함수 형태로 수정 적용 했습니다. 보시고 혜정님 사용하시는 곳에도 수정 부탁드려요!
* 전역 변수 라이브러리로 zustand 적용 했습니다.
* 공통 Modal에 text는 2줄도 있고 sub text도 있어서 children으로 적용했습니다. 모달이 confirm일 경우, 버튼 관련 함수명들에 고민을 많이했는데.... 사용하기 나름이라 생각되는 부분이라 보시고 보완했으면 하는 부분 있으면 알려주세요.
* 모달에 사용하는 text 스타일은 global로 따로 적용해뒀습니다.
* 리뷰 더 보기에 들어가는 모달은 조금 수정이 필요해서 추후 적용 예정입니다.