### PR TITLE
[#117] Review 더보기 리스트 공통 컴포넌트 적용 및 API 연동

### DIFF
--- a/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
+++ b/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
@@ -55,11 +55,12 @@ function AlcoholInfo({ data, handleLogin }: Props) {
               <div
                 className="text-10 flex"
                 onClick={() => {
-                  if (session && data.alcoholId) {
-                    router.push(`/review/register?alcoholId=${data.alcoholId}`);
-                  } else {
+                  if (!session || !data.alcoholId) {
                     handleLogin();
+                    return;
                   }
+
+                  router.push(`/review/register?alcoholId=${data.alcoholId}`);
                 }}
               >
                 <Image

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -145,13 +145,13 @@ function SearchCategory() {
                       <button
                         className="text-10 flex"
                         onClick={() => {
-                          if (session && alcoholId) {
-                            router.push(
-                              `/review/register?alcoholId=${alcoholId}`,
-                            );
-                          } else {
+                          if (!session || !alcoholId) {
                             handleModal();
+                            return;
                           }
+                          router.push(
+                            `/review/register?alcoholId=${alcoholId}`,
+                          );
                         }}
                       >
                         <Image
@@ -257,8 +257,7 @@ function SearchCategory() {
                     <div className="border-b border-mainGray/30" />
                     <Review
                       data={data.reviews.bestReviewInfos[0]}
-                      isBest={true}
-                      isMine={true}
+                      handleLogin={handleModal}
                     />
                   </>
                 )}
@@ -266,7 +265,7 @@ function SearchCategory() {
                 data.reviews.recentReviewInfos.length > 0 &&
                 data.reviews.recentReviewInfos.map((review, index) => (
                   <React.Fragment key={review.userId + index}>
-                    <Review data={review} />
+                    <Review data={review} handleLogin={handleModal} />
                   </React.Fragment>
                 ))}
             </section>

--- a/src/app/api/ReviewApi.ts
+++ b/src/app/api/ReviewApi.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from '@/types/common';
+import { ApiResponse, ListQueryParams } from '@/types/common';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { PreSignedApi } from '@/types/Image';
 import {
@@ -6,6 +6,7 @@ import {
   ReviewPostApi,
   ReviewQueryParams,
   ReviewPatchApi,
+  ReviewListApi,
 } from '@/types/Review';
 import { S3_URL_PATH } from '@/constants/common';
 
@@ -21,6 +22,49 @@ export const ReviewApi = {
 
     const result: ApiResponse<PreSignedApi> = await response;
     return result.data;
+  },
+
+  async getReviewList({
+    alcoholId,
+    sortType,
+    sortOrder,
+    cursor,
+    pageSize,
+  }: ListQueryParams) {
+    const response = await fetchWithAuth(
+      `/bottle-api/reviews/${alcoholId}?sortType=${sortType}&sortOrder=${sortOrder}&cursor=${cursor}&pageSize=${pageSize}`,
+    );
+    console.log(
+      'sortOrder',
+      `/bottle-api/reviews/${alcoholId}?sortType=${sortType}&sortOrder=${sortOrder}&cursor=${cursor}&pageSize=${pageSize}`,
+    );
+    if (response.errors.length !== 0) {
+      throw new Error('Failed to fetch data');
+    }
+
+    const result: ApiResponse<ReviewListApi> = await response;
+
+    return result;
+  },
+
+  async getMyReviewList({
+    alcoholId,
+    sortType,
+    sortOrder,
+    cursor,
+    pageSize,
+  }: ListQueryParams) {
+    const response = await fetchWithAuth(
+      `/bottle-api/reviews/me/${alcoholId}?sortType=${sortType}&sortOrder=${sortOrder}&cursor=${cursor}&pageSize=${pageSize}`,
+    );
+
+    if (response.errors.length !== 0) {
+      throw new Error('Failed to fetch data');
+    }
+
+    const result: ApiResponse<ReviewListApi> = await response;
+
+    return result;
   },
 
   async getReviewDetails(reviewId: string | string[]) {

--- a/src/app/api/ReviewApi.ts
+++ b/src/app/api/ReviewApi.ts
@@ -34,10 +34,6 @@ export const ReviewApi = {
     const response = await fetchWithAuth(
       `/bottle-api/reviews/${alcoholId}?sortType=${sortType}&sortOrder=${sortOrder}&cursor=${cursor}&pageSize=${pageSize}`,
     );
-    console.log(
-      'sortOrder',
-      `/bottle-api/reviews/${alcoholId}?sortType=${sortType}&sortOrder=${sortOrder}&cursor=${cursor}&pageSize=${pageSize}`,
-    );
     if (response.errors.length !== 0) {
       throw new Error('Failed to fetch data');
     }

--- a/src/types/Review.ts
+++ b/src/types/Review.ts
@@ -1,17 +1,17 @@
 export interface Review {
   userId: number;
-  imageUrl: null | string; // 다음주 server 확인 예정
+  userProfileImage: null | string;
   nickName: string;
   reviewId: number;
   reviewContent: string;
   rating: number;
   sizeType: string; // "BOTTLE", "GLASS"
   price: number;
-  viewCount: number;
   likeCount: number;
-  isMyLike: boolean;
+  isLikedByMe: boolean;
   replyCount: number;
-  isMyReply: boolean;
+  isMyReview: boolean;
+  hasReplyByMe: boolean;
   status: 'PUBLIC' | 'PRIVATE';
   reviewImageUrl: null | string;
   createAt: string;
@@ -34,6 +34,11 @@ export interface FormValues {
   zipCode?: string | null;
   address?: string | null;
   detailAddress?: string | null;
+}
+
+export interface ReviewListApi {
+  reviewList: Review[];
+  totalCount: number;
 }
 
 export interface AlcoholInfo {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -21,8 +21,8 @@ export const enum SORT_TYPE {
   PICK = 'PICK',
   REVIEW = 'REVIEW',
   RANDOM = 'RANDOM',
-  BOTTLE_ASC = 'BOTTLE_ASC',
-  GLASS_ASC = 'GLASS_ASC',
+  BOTTLE_PRICE = 'BOTTLE_PRICE',
+  GLASS_PRICE = 'GLASS_PRICE',
 }
 
 export const enum SORT_ORDER {
@@ -33,6 +33,7 @@ export const enum SORT_ORDER {
 export interface ListQueryParams {
   keyword?: string;
   category?: string;
+  alcoholId?: string;
   regionId?: number | '';
   sortType?: SORT_TYPE;
   sortOrder?: SORT_ORDER;


### PR DESCRIPTION
### PR 제목 (Title)

* [#117] Review 더보기 리스트 공통 컴포넌트 적용 및 API 연동

### 변경 사항 (Changes)

 - [x] 공통 LIST 컴포넌트, filter 적용
 - [x] 공통 무한스크롤 적용
 - [x] 리뷰 리스트, 내가 쓴 리뷰 리스트 API 연동
 - [x] 좋아요 컴포넌트 적용
 - [x] 로그인 여부 확인 로직 적용

### 테스트 방법 (Test Procedure)

1. home에서 알콜 화면 클릭해서 이동 후 '리뷰 더보기' 버튼 클릭해서 이동

### 참고 사항 (Additional Information)
* 카테고리 폴더 layout.tsx에 NavLayout 컴포넌트를 page.tsx로 옮겨주셔야할 것 같아요. 카테고리 안에 review 페이지에서 네브바가 안보여야해서요!
* 공통 type에 SORT_TYPE에서   BOTTLE_PRICE, GLASS_PRICE 수정했는데 혹시 혜정님 API랑  다르면 코멘트 부탁드려요.
* 다음 PR에서 optionModal 수정, 삭제하기에 modal 적용 예정입니다.
* 베스트 리뷰인지 여부를 보여줘야 하는데 아직 API에 반영이 안되어서 있어서 추후 적용 예정입니다.