### PR TITLE
[#116] 별점 요청 API 연동

### DIFF
--- a/src/app/(primary)/layout.tsx
+++ b/src/app/(primary)/layout.tsx
@@ -1,11 +1,18 @@
+'use client';
+
+import useModalStore from '@/store/modalStore';
+import LoginModal from './_components/LoginModal';
+
 export default function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { isShowLoginModal, handleLoginModal } = useModalStore();
   return (
-    <div className="bg-white flex flex-col w-full mx-auto max-w-[430px] min-h-screen">
-      <main className="flex-1 overflow-y-auto">{children}</main>
-    </div>
+    <main className="bg-white flex flex-col w-full mx-auto max-w-[430px] min-h-screen">
+      <section className="flex-1 overflow-y-auto">{children}</section>
+      {isShowLoginModal && <LoginModal handleClose={handleLoginModal} />}
+    </main>
   );
 }

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -39,32 +39,30 @@ const ListItemRating = ({ data }: Props) => {
   };
 
   return (
-    <>
-      <article className="flex items-center space-x-2 text-mainBlack border-brightGray border-b h-[90px]">
-        <ItemImage src={imageUrl} alt="위스키 이미지" />
-        <section className="flex-1 space-y-1">
-          <ItemInfo
-            korName={korName}
-            engName={engName}
-            korCategory={korCategory}
-          />
-          <article className="flex justify-between">
-            <StarRating rate={rate} handleRate={handleRate} />
-            <div className="space-x-1.5 flex items-end">
-              <PickBtn
-                isPicked={isPicked}
-                alcoholId={alcoholId}
-                iconColor="subcoral"
-                // FIXME: 별도 함수로 분리
-                handleUpdatePicked={() => setIsPicked(!isPicked)}
-                handleError={() => alert('에러가 발생했습니다.')}
-                handleNotLogin={() => alert('로그인이 필요한 서비스입니다.')}
-              />
-            </div>
-          </article>
-        </section>
-      </article>
-    </>
+    <article className="flex items-center space-x-2 text-mainBlack border-brightGray border-b h-[90px]">
+      <ItemImage src={imageUrl} alt="위스키 이미지" />
+      <section className="flex-1 space-y-1">
+        <ItemInfo
+          korName={korName}
+          engName={engName}
+          korCategory={korCategory}
+        />
+        <article className="flex justify-between">
+          <StarRating rate={rate} handleRate={handleRate} />
+          <div className="space-x-1.5 flex items-end">
+            <PickBtn
+              isPicked={isPicked}
+              alcoholId={alcoholId}
+              iconColor="subcoral"
+              // FIXME: 별도 함수로 분리
+              handleUpdatePicked={() => setIsPicked(!isPicked)}
+              handleError={() => alert('에러가 발생했습니다.')}
+              handleNotLogin={() => alert('로그인이 필요한 서비스입니다.')}
+            />
+          </div>
+        </article>
+      </section>
+    </article>
   );
 };
 

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { RateAPI } from '@/types/Rate';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
+import { RateApi } from '@/app/api/RateApi';
 import ItemInfo from './_components/ItemInfo';
 import ItemImage from './_components/ItemImage';
 import StarRating from '../StarRaiting';
@@ -23,9 +24,12 @@ const ListItemRating = ({ data }: Props) => {
   const [rate, setRate] = useState(0);
   const [isPicked, setIsPicked] = useState(initialIsPicked);
 
-  const handleRate = (selectedRate: number) => {
+  const handleRate = async (selectedRate: number) => {
     setRate(selectedRate);
-    // TODO: 서버에 별점 업데이트 요청
+    return RateApi.postRating({
+      alcoholId: String(alcoholId),
+      rating: selectedRate,
+    });
   };
 
   return (

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -6,7 +6,6 @@ import { RateAPI } from '@/types/Rate';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
 import { RateApi } from '@/app/api/RateApi';
 import useModalStore from '@/store/modalStore';
-import LoginModal from '@/app/(primary)/_components/LoginModal';
 import ItemInfo from './_components/ItemInfo';
 import ItemImage from './_components/ItemImage';
 import StarRating from '../StarRaiting';
@@ -27,11 +26,10 @@ const ListItemRating = ({ data }: Props) => {
   const { data: session } = useSession();
   const [rate, setRate] = useState(0);
   const [isPicked, setIsPicked] = useState(initialIsPicked);
-  const { isShowModal: isLoginModalShow, handleModal: handleLoginModalShow } =
-    useModalStore();
+  const { handleLoginModal } = useModalStore();
 
   const handleRate = async (selectedRate: number) => {
-    if (!session) return handleLoginModalShow();
+    if (!session) return handleLoginModal();
 
     setRate(selectedRate);
     return RateApi.postRating({
@@ -66,7 +64,6 @@ const ListItemRating = ({ data }: Props) => {
           </article>
         </section>
       </article>
-      {isLoginModalShow && <LoginModal handleClose={handleLoginModalShow} />}
     </>
   );
 };

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { useSession } from 'next-auth/react';
 import { RateAPI } from '@/types/Rate';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
 import { RateApi } from '@/app/api/RateApi';
+import useModalStore from '@/store/modalStore';
+import LoginModal from '@/app/(primary)/_components/LoginModal';
 import ItemInfo from './_components/ItemInfo';
 import ItemImage from './_components/ItemImage';
 import StarRating from '../StarRaiting';
@@ -21,10 +24,15 @@ const ListItemRating = ({ data }: Props) => {
     isPicked: initialIsPicked,
     alcoholId,
   } = data;
+  const { data: session } = useSession();
   const [rate, setRate] = useState(0);
   const [isPicked, setIsPicked] = useState(initialIsPicked);
+  const { isShowModal: isLoginModalShow, handleModal: handleLoginModalShow } =
+    useModalStore();
 
   const handleRate = async (selectedRate: number) => {
+    if (!session) return handleLoginModalShow();
+
     setRate(selectedRate);
     return RateApi.postRating({
       alcoholId: String(alcoholId),
@@ -33,30 +41,33 @@ const ListItemRating = ({ data }: Props) => {
   };
 
   return (
-    <article className="flex items-center space-x-2 text-mainBlack border-brightGray border-b h-[90px]">
-      <ItemImage src={imageUrl} alt="위스키 이미지" />
-      <section className="flex-1 space-y-1">
-        <ItemInfo
-          korName={korName}
-          engName={engName}
-          korCategory={korCategory}
-        />
-        <article className="flex justify-between">
-          <StarRating rate={rate} handleRate={handleRate} />
-          <div className="space-x-1.5 flex items-end">
-            <PickBtn
-              isPicked={isPicked}
-              alcoholId={alcoholId}
-              iconColor="subcoral"
-              // FIXME: 별도 함수로 분리
-              handleUpdatePicked={() => setIsPicked(!isPicked)}
-              handleError={() => alert('에러가 발생했습니다.')}
-              handleNotLogin={() => alert('로그인이 필요한 서비스입니다.')}
-            />
-          </div>
-        </article>
-      </section>
-    </article>
+    <>
+      <article className="flex items-center space-x-2 text-mainBlack border-brightGray border-b h-[90px]">
+        <ItemImage src={imageUrl} alt="위스키 이미지" />
+        <section className="flex-1 space-y-1">
+          <ItemInfo
+            korName={korName}
+            engName={engName}
+            korCategory={korCategory}
+          />
+          <article className="flex justify-between">
+            <StarRating rate={rate} handleRate={handleRate} />
+            <div className="space-x-1.5 flex items-end">
+              <PickBtn
+                isPicked={isPicked}
+                alcoholId={alcoholId}
+                iconColor="subcoral"
+                // FIXME: 별도 함수로 분리
+                handleUpdatePicked={() => setIsPicked(!isPicked)}
+                handleError={() => alert('에러가 발생했습니다.')}
+                handleNotLogin={() => alert('로그인이 필요한 서비스입니다.')}
+              />
+            </div>
+          </article>
+        </section>
+      </article>
+      {isLoginModalShow && <LoginModal handleClose={handleLoginModalShow} />}
+    </>
   );
 };
 

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -2,12 +2,17 @@ import { create } from 'zustand';
 
 interface ModalStore {
   isShowModal: boolean;
+  isShowLoginModal: boolean;
   handleModal: () => void;
+  handleLoginModal: () => void;
 }
 
 const useModalStore = create<ModalStore>((set) => ({
   isShowModal: false,
+  isShowLoginModal: false,
   handleModal: () => set((state) => ({ isShowModal: !state.isShowModal })),
+  handleLoginModal: () =>
+    set((state) => ({ isShowLoginModal: !state.isShowLoginModal })),
 }));
 
 export default useModalStore;


### PR DESCRIPTION
### PR 제목 (Title)

* 별점 요청 API 연동

### 변경 사항 (Changes)

* 체크리스트
  - [x] 로그인 상태에서 별점 api 요청
  - [x] 로그인되지 않은 상태에서 모달 띄워줌
  - [x] useModalStore 에 로그인 모달 관련 전역 상태/핸들러 추가

### 변경 이유 (Reason for Changes)

* 로그인 모달의 중복 렌더링 방지

### 테스트 방법 (Test Procedure)

* 별점 페이지에서 로그인 전/후 별점 매기기 체크

### 참고 사항 (Additional Information)

* 별점을 드래그해서 매기는 UX는 개선이 필요합니다. (별도 이슈 추가됨)
