### PR TITLE
 [#138] Review 상세조회에 대댓글 리스트 및 대댓글 입력 로직 수정

### DIFF
--- a/src/app/(primary)/review/[id]/_components/Reply/Reply.tsx
+++ b/src/app/(primary)/review/[id]/_components/Reply/Reply.tsx
@@ -105,20 +105,21 @@ function Reply({
             <p className="text-mainGray text-10">
               {formatDate(data?.createAt)}
             </p>
-            {/* 삭제된 댓글에 대한 조건 추가 필요 API 수정되면 적용 예정 */}
-            <button
-              className="cursor-pointer"
-              onClick={() => {
-                setIsOptionShow(true);
-              }}
-            >
-              <Image
-                src="/icon/ellipsis-darkgray.svg"
-                width={10}
-                height={10}
-                alt="report"
-              />
-            </button>
+            {data?.status !== 'DELETED' && (
+              <button
+                className="cursor-pointer"
+                onClick={() => {
+                  setIsOptionShow(true);
+                }}
+              >
+                <Image
+                  src="/icon/ellipsis-darkgray.svg"
+                  width={10}
+                  height={10}
+                  alt="report"
+                />
+              </button>
+            )}
           </div>
         </div>
         <div className="text-10 text-mainDarkGray whitespace-pre-wrap break-words flex">
@@ -129,10 +130,14 @@ function Reply({
         </div>
         <div className="space-y-1">
           <div className="flex space-x-2">
-            {/* 삭제된 댓글에 대한 조건 추가 필요 API 수정되면 적용 예정 */}
-            <button className="text-10 text-subCoral" onClick={updateReplyUser}>
-              답글 달기
-            </button>
+            {data?.status !== 'DELETED' && (
+              <button
+                className="text-10 text-subCoral"
+                onClick={updateReplyUser}
+              >
+                답글 달기
+              </button>
+            )}
             {'subReplyCount' in data && data?.subReplyCount !== 0 && (
               <button
                 className="flex items-center space-x-[2px]"

--- a/src/app/(primary)/review/[id]/page.tsx
+++ b/src/app/(primary)/review/[id]/page.tsx
@@ -52,10 +52,7 @@ export default function ReviewDetail() {
     resolver: yupResolver(schema),
   });
 
-  const {
-    reset,
-    // formState: { isDirty, errors },
-  } = formMethods;
+  const { reset, setValue } = formMethods;
 
   const handleLogin = () => {
     setModalType('login');
@@ -76,9 +73,26 @@ export default function ReviewDetail() {
   };
 
   const handleCreateReply: SubmitHandler<FieldValues> = async (data) => {
+    let saveContent = data.content;
+    let saveParentReplyId = data.parentReplyId;
+
+    const replyToReplyUserName = data.content.match(/@(\S+?)\s/);
+
+    if (
+      replyToReplyUserName &&
+      replyToReplyUserName[1] === data.replyToReplyUserName
+    ) {
+      saveContent = data.content.replace(/@(\S+?)\s/, '');
+      setValue('content', saveContent);
+    } else {
+      saveParentReplyId = null;
+      setValue('parentReplyId', null);
+      setValue('replyToReplyUserName', null);
+    }
+
     const replyParams = {
-      content: data.content,
-      parentReplyId: data.parentReplyId,
+      content: saveContent,
+      parentReplyId: saveParentReplyId,
     };
 
     const response = await ReplyApi.registerReply(

--- a/src/app/(primary)/review/[id]/page.tsx
+++ b/src/app/(primary)/review/[id]/page.tsx
@@ -52,7 +52,7 @@ export default function ReviewDetail() {
     resolver: yupResolver(schema),
   });
 
-  const { reset, setValue } = formMethods;
+  const { reset } = formMethods;
 
   const handleLogin = () => {
     setModalType('login');
@@ -83,11 +83,8 @@ export default function ReviewDetail() {
       replyToReplyUserName[1] === data.replyToReplyUserName
     ) {
       saveContent = data.content.replace(/@(\S+?)\s/, '');
-      setValue('content', saveContent);
     } else {
       saveParentReplyId = null;
-      setValue('parentReplyId', null);
-      setValue('replyToReplyUserName', null);
     }
 
     const replyParams = {

--- a/src/types/Reply.ts
+++ b/src/types/Reply.ts
@@ -5,6 +5,7 @@ export interface Reply {
   reviewReplyId: number;
   reviewReplyContent: string;
   createAt: string;
+  status: 'NORMAL' | 'DELETED' | 'HIDDEN' | 'BLOCKED';
 }
 
 export interface RootReply extends Reply {


### PR DESCRIPTION
### PR 제목 (Title)

*  [#138 ] Review 상세조회에 대댓글 리스트 및 대댓글 입력 로직 수정

### 변경 사항 (Changes)

 - [x] 대댓글 리스트 data format 수정
 - [x] 대댓글 입력 시 맨션 레이아웃 및 로직 수정
 - [x] 삭제된 댓글에 불필요한 버튼 조건 추가

### 테스트 방법 (Test Procedure)

1. localhost/review/35

### 참고 사항 (Additional Information)
* 답글 달기를 누르면 @username이 다른 색으로 나와야 하는데 아직 이건 해결을 못 했어요. 기능적인 문제가 아니라 추후 개발로 넘기려고 합니다..!
* 대댓글을 남기면 해당 댓글의 토글이 열리면서 남긴 대댓글이 보이는게 좋을 것 같은데, 해당 부분은 서버에서 추가적으로 id를 보내줘야 가능할 것 같아서 서버담당자와 이야기 후에 반영 예정입니다.