### PR TITLE
[#131] 프로필 수정 (닉네임 수정, 모달 로직 개선, 에러 response 개선)

### DIFF
--- a/src/app/(primary)/user/[id]/_components/ProfileImage.tsx
+++ b/src/app/(primary)/user/[id]/_components/ProfileImage.tsx
@@ -1,0 +1,20 @@
+import Image from 'next/image';
+import ProfileDefaultImg from 'public/profile-default.svg';
+
+interface Props {
+  profileImgSrc: string | null;
+}
+
+function ProfileImage({ profileImgSrc }: Props) {
+  return (
+    <Image
+      src={profileImgSrc ?? ProfileDefaultImg}
+      alt="프로필 이미지"
+      width={104}
+      height={104}
+      className="rounded-full border-2 border-subCoral"
+    />
+  );
+}
+
+export default ProfileImage;

--- a/src/app/(primary)/user/[id]/_components/UserInfo.tsx
+++ b/src/app/(primary)/user/[id]/_components/UserInfo.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import ProfileDefaultImg from 'public/profile-default.svg';
+import ProfileImage from './ProfileImage';
 
 interface Props {
   profileImgSrc: string | null;
@@ -15,8 +14,6 @@ interface Props {
   nickName: string;
 }
 
-// 이 아이의 역할
-// 3. 내 프로필일 경우 프로필 수정 페이지로 이동
 const UserInfo = ({
   profileImgSrc = null,
   follower,
@@ -35,12 +32,7 @@ const UserInfo = ({
 
   return (
     <section className="flex space-x-5.25 py-8.75 border-b border-t border-subCoral">
-      <Image
-        src={profileImgSrc ?? ProfileDefaultImg}
-        alt="프로필 이미지"
-        width={104}
-        height={104}
-      />
+      <ProfileImage profileImgSrc={profileImgSrc} />
 
       <article className="space-y-2.5">
         <h1 className="text-3xl font-bold text-subCoral">{nickName}</h1>

--- a/src/app/(primary)/user/[id]/edit/_components/EditForm.tsx
+++ b/src/app/(primary)/user/[id]/edit/_components/EditForm.tsx
@@ -6,6 +6,7 @@ import { UserApi } from '@/app/api/UserApi';
 import { validate } from '@/utils/validate';
 import Modal from '@/components/Modal';
 import useModalStore from '@/store/modalStore';
+import { ApiResponse } from '@/types/common';
 import CloseIconGray from 'public/icon/close-brightgray.svg';
 
 function EditForm() {
@@ -47,15 +48,23 @@ function EditForm() {
     }
 
     try {
-      await UserApi.changeNickname(newNickName);
+      const result = await UserApi.changeNickname(newNickName);
 
-      return handleModalState({
-        isShowModal: true,
-        mainText: `저장되었습니다.`,
-      });
+      if (result.code === 200) {
+        return handleModalState({
+          isShowModal: true,
+          mainText: `저장되었습니다.`,
+        });
+      }
     } catch (e) {
-      // TODO: 에러 상태 코드에 따른 메시지 분기처리
-      // const error = e as ApiResponse<unknown>;
+      const errorRes = e as ApiResponse<any>;
+      if (errorRes.errors[0].code === 'USER_NICKNAME_NOT_VALID') {
+        return handleModalState({
+          isShowModal: true,
+          mainText: `이미 사용중인 닉네임입니다.👀`,
+          subText: `다른 닉네임으로 변경해주세요.`,
+        });
+      }
 
       return handleModalState({
         isShowModal: true,

--- a/src/app/(primary)/user/[id]/edit/_components/EditForm.tsx
+++ b/src/app/(primary)/user/[id]/edit/_components/EditForm.tsx
@@ -10,8 +10,7 @@ import CloseIconGray from 'public/icon/close-brightgray.svg';
 
 function EditForm() {
   const [nickName, setNickName] = useState('');
-  const { handleModal } = useModalStore();
-  const [modalMsg, setModalMsg] = useState({ main: '', sub: '' });
+  const { handleModalState, state } = useModalStore();
   // const [birthDate, setBirthDate] = useState('');
   // const [gender, setGender] = useState<'MALE' | 'FEMALE' | null>(null);
 
@@ -41,28 +40,28 @@ function EditForm() {
 
   const handelRegisterNickName = async (newNickName: string) => {
     if (!validateNickName(newNickName)) {
-      setModalMsg({
-        main: `닉네임은 2 ~ 11자의\n한글, 영문, 숫자만 가능합니다.`,
-        sub: '',
+      return handleModalState({
+        isShowModal: true,
+        mainText: `닉네임은 2 ~ 11자의\n한글, 영문, 숫자만 가능합니다.`,
       });
-      return handleModal();
     }
+
     try {
       await UserApi.changeNickname(newNickName);
-      setModalMsg({
-        main: `저장되었습니다.`,
-        sub: '',
+
+      return handleModalState({
+        isShowModal: true,
+        mainText: `저장되었습니다.`,
       });
     } catch (e) {
       // TODO: 에러 상태 코드에 따른 메시지 분기처리
       // const error = e as ApiResponse<unknown>;
-      setModalMsg({
-        main: `변경 및 저장에 실패했습니다.`,
-        sub: '',
+
+      return handleModalState({
+        isShowModal: true,
+        mainText: `변경 및 저장에 실패했습니다..`,
       });
     }
-
-    handleModal();
   };
 
   // const handleGender = (selectedGender: 'MALE' | 'FEMALE') => {
@@ -160,7 +159,7 @@ function EditForm() {
         </article>
       </div> */}
       </div>
-      <Modal mainText={modalMsg.main} subText={modalMsg.sub} />
+      <Modal mainText={state.mainText} subText={state.subText} />
     </>
   );
 }

--- a/src/app/(primary)/user/[id]/edit/_components/EditForm.tsx
+++ b/src/app/(primary)/user/[id]/edit/_components/EditForm.tsx
@@ -60,8 +60,9 @@ function EditForm() {
         main: `변경 및 저장에 실패했습니다.`,
         sub: '',
       });
-      handleModal();
     }
+
+    handleModal();
   };
 
   // const handleGender = (selectedGender: 'MALE' | 'FEMALE') => {

--- a/src/app/(primary)/user/[id]/edit/page.tsx
+++ b/src/app/(primary)/user/[id]/edit/page.tsx
@@ -6,6 +6,9 @@ import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
 import OptionDropdown from '@/components/OptionDropdown';
+import { UserApi } from '@/app/api/UserApi';
+import useModalStore from '@/store/modalStore';
+import Modal from '@/components/Modal';
 import EditForm from './_components/EditForm';
 import ProfileDefaultImg from 'public/profile-default.svg';
 import ChangeProfile from 'public/change-profile.svg';
@@ -13,6 +16,7 @@ import ChangeProfile from 'public/change-profile.svg';
 export default function UserEditPage() {
   const router = useRouter();
   const { data: session } = useSession();
+  const { handleModalState, state } = useModalStore();
   const [isOptionShow, setIsOptionShow] = useState(false);
 
   const SELECT_OPTIONS = [
@@ -21,17 +25,25 @@ export default function UserEditPage() {
     { type: 'delete', name: '현재 이미지 삭제하기' },
   ];
 
-  // TODO: 타입 가드 추가
-  const handleOptionSelect = ({
-    type,
-    name,
-  }: {
-    type: string;
-    name: string;
-  }) => {
+  const handleOptionSelect = async ({ type }: { type: string }) => {
+    if (type === 'camera') return alert(`카메라 접근 기능 준비중입니다.`);
+    if (type === 'album') return alert(`앨범 접근 기능 준비중입니다.`);
+    if (type === 'delete') {
+      try {
+        await UserApi.changeProfileImage(null);
+        handleModalState({
+          isShowModal: true,
+          mainText: '저장되었습니다.',
+          handleConfirm: () => {
+            router.push(`/user/${session?.user.userId}`);
+          },
+        });
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
     setIsOptionShow(false);
-    alert(`선택한 옵션: ${name}${type}, 업로드 기능 준비중입니다.`);
-    // TODO: type 에 따른 로직 추가
   };
 
   return (
@@ -84,6 +96,11 @@ export default function UserEditPage() {
           handleClose={() => setIsOptionShow(false)}
         />
       )}
+      <Modal
+        mainText={state.mainText}
+        subText={state.subText}
+        handleConfirm={state.handleConfirm}
+      />
     </main>
   );
 }

--- a/src/app/api/CommonApi.ts
+++ b/src/app/api/CommonApi.ts
@@ -1,18 +1,19 @@
+import { S3_URL_PATH } from '@/constants/common';
+import { ApiResponse } from '@/types/common';
+import { PreSignedApi } from '@/types/Image';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 
 export const CommonApi = {
-  async getUploadUrl({
-    rootPath = 'test',
-    uploadSize = 1,
-  }: {
-    rootPath?: string;
-    uploadSize?: number;
-  }) {
+  async getUploadUrl(type: keyof typeof S3_URL_PATH, images: File[]) {
     const response = await fetchWithAuth(
-      `/bottle-api/s3/presign-url?rootPath=${rootPath}&uploadSize=${uploadSize}`,
+      `/bottle-api/s3/presign-url?rootPath=${S3_URL_PATH[type]}&uploadSize=${images.length}`,
     );
 
-    const { data } = await response.json();
-    return data.accessToken;
+    if (response.errors.length !== 0) {
+      throw new Error('Failed to fetch data');
+    }
+
+    const result: ApiResponse<PreSignedApi> = await response;
+    return result.data;
   },
 };

--- a/src/app/api/ReviewApi.ts
+++ b/src/app/api/ReviewApi.ts
@@ -1,6 +1,5 @@
 import { ApiResponse, ListQueryParams } from '@/types/common';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
-import { PreSignedApi } from '@/types/Image';
 import {
   ReviewDetailsApi,
   ReviewPostApi,
@@ -9,22 +8,8 @@ import {
   ReviewLikePutApi,
   ReviewListApi,
 } from '@/types/Review';
-import { S3_URL_PATH } from '@/constants/common';
 
 export const ReviewApi = {
-  async getPreSignedURL(type: keyof typeof S3_URL_PATH, images: File[]) {
-    const response = await fetchWithAuth(
-      `/bottle-api/s3/presign-url?rootPath=${S3_URL_PATH[type]}&uploadSize=${images.length}`,
-    );
-
-    if (response.errors.length !== 0) {
-      throw new Error('Failed to fetch data');
-    }
-
-    const result: ApiResponse<PreSignedApi> = await response;
-    return result.data;
-  },
-
   async getReviewList({
     alcoholId,
     sortType,

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -3,16 +3,16 @@ import { UserInfoApi } from '@/types/User';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 
 export const UserApi = {
-  async changeNickname() {
+  async changeNickname(nickName: string) {
     const response = await fetchWithAuth(`/bottle-api/users/nickname`, {
       method: 'PATCH',
       body: JSON.stringify({
-        nickName: '에헤?',
+        nickName,
       }),
     });
 
-    const { data } = await response.json();
-    return data.accessToken;
+    const { data } = response;
+    return data;
   },
 
   async getUserInfo({ userId }: { userId: string }) {

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -29,7 +29,7 @@ export const UserApi = {
   },
 
   async changeProfileImage(profileImageSrc: string | null) {
-    const response = await fetchWithAuth(`/bottle-api//users/profile-image`, {
+    const response = await fetchWithAuth(`/bottle-api/users/profile-image`, {
       method: 'PATCH',
       body: JSON.stringify({
         viewUrl: profileImageSrc,

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -3,7 +3,14 @@ import { UserInfoApi } from '@/types/User';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 
 export const UserApi = {
-  async changeNickname(nickName: string) {
+  async changeNickname(nickName: string): Promise<
+    ApiResponse<{
+      message: string;
+      userId: number;
+      beforeNickname: string;
+      changedNickname: string;
+    }>
+  > {
     const response = await fetchWithAuth(`/bottle-api/users/nickname`, {
       method: 'PATCH',
       body: JSON.stringify({
@@ -11,12 +18,11 @@ export const UserApi = {
       }),
     });
 
-    const { data } = response;
-    return data;
+    return response;
   },
 
   async getUserInfo({ userId }: { userId: string }) {
-    const response = await fetchWithAuth(`/bottle-api/mypage/${userId}`);
+    const response = await fetchWithAuth(`/bottle-api/my-page/${userId}`);
     const { data }: ApiResponse<UserInfoApi> = response;
 
     return data;

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -21,4 +21,23 @@ export const UserApi = {
 
     return data;
   },
+
+  async changeProfileImage(profileImageSrc: string | null) {
+    const response = await fetchWithAuth(`/bottle-api//users/profile-image`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        viewUrl: profileImageSrc,
+      }),
+    });
+
+    const {
+      data,
+    }: ApiResponse<{
+      userId: string;
+      profileImageUrl: string | null;
+      callback: string;
+    }> = response;
+
+    return data;
+  },
 };

--- a/src/app/api/token/renew/route.ts
+++ b/src/app/api/token/renew/route.ts
@@ -16,6 +16,7 @@ export async function POST(req: NextRequest, res: NextResponse) {
   const { refreshToken } = decoded;
 
   try {
+    console.log('기존 세션', session);
     const newTokens = await AuthApi.renewAccessToken(refreshToken);
     const newSessionToken = await encode({
       secret: process.env.NEXTAUTH_SECRET as string,
@@ -26,6 +27,8 @@ export async function POST(req: NextRequest, res: NextResponse) {
       },
       maxAge: 30 * 24 * 60 * 60,
     });
+
+    console.log('새 세션', newSessionToken);
 
     cookies().set({
       name: sessionCookie,

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import Image from 'next/image';
 import BackDrop from '@/components/BackDrop';
 import useModalStore from '@/store/modalStore';
@@ -26,20 +27,36 @@ function Modal({
   mainText,
   subText,
 }: Props) {
-  const { isShowModal, handleModal } = useModalStore();
+  const { handleCloseModal, handleModalState, state } = useModalStore();
 
   const handleOkayClick = () => {
-    if (handleConfirm) handleConfirm();
-    else handleModal();
+    if (state.handleConfirm) state.handleConfirm();
+    else handleCloseModal();
   };
 
   const handleCancelClick = () => {
     if (handleCancel) handleCancel();
-    else handleModal();
+    else handleCloseModal();
   };
 
+  useEffect(() => {
+    return () => {
+      handleModalState({
+        isShowModal: false,
+        type: 'ALERT',
+        mainText: '',
+        subText: '',
+        alertBtnName: '확인',
+        confirmBtnName: '취소',
+        cancelBtnName: '확인',
+        handleCancel: null,
+        handleConfirm: null,
+      });
+    };
+  }, []);
+
   return (
-    <BackDrop isShow={isShowModal}>
+    <BackDrop isShow={state.isShowModal}>
       <div className="w-full h-full flex flex-col justify-center items-center px-4 gap-3">
         <section className="relative w-full min-h-52 pt-16 pb-4 bg-white rounded-xl text-center flex flex-col items-center space-y-4 px-4">
           <article className="absolute top-[-10px]">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -8,8 +8,8 @@ interface Props {
   type?: 'alert' | 'confirm';
   children?: React.ReactNode;
   alertBtnName?: string;
-  handleCancel?: () => void;
-  handleConfirm?: () => void;
+  handleCancel?: (() => void) | null;
+  handleConfirm?: (() => void) | null;
   confirmBtnName?: string;
   cancelBtnName?: string;
   mainText?: string;
@@ -30,7 +30,7 @@ function Modal({
   const { handleCloseModal, handleModalState, state } = useModalStore();
 
   const handleOkayClick = () => {
-    if (state.handleConfirm) state.handleConfirm();
+    if (handleConfirm) handleConfirm();
     else handleCloseModal();
   };
 

--- a/src/components/OptionDropdown.tsx
+++ b/src/components/OptionDropdown.tsx
@@ -3,7 +3,7 @@ import BackDrop from './BackDrop';
 interface Props {
   handleClose: () => void;
   options: { type: string; name: string }[];
-  handleOptionSelect: ({ type, name }: { type: string; name: string }) => void;
+  handleOptionSelect: (args: any) => void;
   title?: string;
 }
 

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,18 +1,49 @@
 import { create } from 'zustand';
 
-interface ModalStore {
+interface ModalState {
   isShowModal: boolean;
-  isShowLoginModal: boolean;
-  handleModal: () => void;
-  handleLoginModal: () => void;
+  type: 'ALERT' | 'CONFIRM';
+  mainText: string;
+  subText: string;
+  alertBtnName: string;
+  confirmBtnName: string;
+  cancelBtnName: string;
+  handleCancel: (() => void) | null;
+  handleConfirm: (() => void) | null;
+}
+
+type ParcialModalState = {
+  [K in keyof ModalState]?: ModalState[K];
+};
+
+interface ModalStore {
+  state: ModalState;
+  handleModalState: (state: ParcialModalState) => void;
+  handleCloseModal: () => void;
 }
 
 const useModalStore = create<ModalStore>((set) => ({
-  isShowModal: false,
-  isShowLoginModal: false,
-  handleModal: () => set((state) => ({ isShowModal: !state.isShowModal })),
-  handleLoginModal: () =>
-    set((state) => ({ isShowLoginModal: !state.isShowLoginModal })),
+  state: {
+    isShowModal: false,
+    type: 'ALERT',
+    mainText: '',
+    subText: '',
+    alertBtnName: '확인',
+    confirmBtnName: '취소',
+    cancelBtnName: '확인',
+    handleCancel: null,
+    handleConfirm: null,
+  },
+  handleModalState: (newState) =>
+    set((state) => ({
+      state: {
+        ...state.state,
+        ...newState,
+      },
+    })),
+  handleCloseModal: () => {
+    set((state) => ({ state: { ...state.state, isShowModal: false } }));
+  },
 }));
 
 export default useModalStore;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -4,7 +4,7 @@ export interface ApiResponse<T> {
   success: boolean;
   code: number;
   data: T;
-  errors: any;
+  errors: any; // FIXME: 백엔드 수정 후 에러 타입 추가
   meta: {
     serverEncoding: string;
     serverVersion: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -4,7 +4,7 @@ export interface ApiResponse<T> {
   success: boolean;
   code: number;
   data: T;
-  errors: any; // FIXME: 백엔드 수정 후 에러 타입 추가
+  errors: ErrorResponse[];
   meta: {
     serverEncoding: string;
     serverVersion: string;
@@ -12,6 +12,12 @@ export interface ApiResponse<T> {
     serverResponseTime: string;
     pageable?: { pageSize: number; hasNext: boolean; currentCursor: number };
   };
+}
+
+export interface ErrorResponse {
+  code: string;
+  message: string;
+  status: string; // NOTE: 정확히 어떤 status가 존재하는지 알면 더 좋겠다.
 }
 
 // TODO: 두 개의 sort type 으로 분리할 것 (리뷰, 위스키 조회 ...)

--- a/src/utils/ApiError.ts
+++ b/src/utils/ApiError.ts
@@ -1,0 +1,8 @@
+export class ApiError extends Error {
+  response: Response;
+
+  constructor(message: string, response: Response) {
+    super(message);
+    this.response = response;
+  }
+}

--- a/src/utils/S3Upload.ts
+++ b/src/utils/S3Upload.ts
@@ -1,4 +1,4 @@
-import { ReviewApi } from '@/app/api/ReviewApi';
+import { CommonApi } from '@/app/api/CommonApi';
 import { S3_URL_PATH } from '@/constants/common';
 
 export async function uploadImages(
@@ -8,7 +8,7 @@ export async function uploadImages(
   const imageArray = Array.isArray(images) ? images : [images];
 
   // GET preSignedURL
-  const preSignedData = await ReviewApi.getPreSignedURL(type, imageArray);
+  const preSignedData = await CommonApi.getUploadUrl(type, imageArray);
 
   // Upload images
   const uploadPromises = imageArray.map((image, index) => {

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,32 @@
+export const validate = {
+  length: ({
+    value,
+    min,
+    max,
+  }: {
+    value: string;
+    min: number;
+    max?: number;
+  }) => {
+    if (value.length < min) {
+      return false;
+    }
+
+    if (max && value.length > max) {
+      return false;
+    }
+
+    return true;
+  },
+
+  isKoreanAlphaNumeric: (value: string) => {
+    const regex = /[^a-zA-Z가-힣0-9]/;
+    const result = regex.test(value);
+
+    return !result;
+  },
+
+  hasSpace: (value: string) => {
+    return /\s/.test(value);
+  },
+};


### PR DESCRIPTION


### PR 제목 (Title)

[#131] 프로필 수정 (닉네임 수정, 모달 로직 개선, 에러 response 개선)

### 변경 사항 (Changes)

* 체크리스트
  - [x] 닉네임 수정 api 연동
  - [x] 프로필 삭제 api 연동
  - [x] 모달 스토어 핸들러, 상태 개선 (중앙 스토어에서 대부분의 값을 관리, 모달 스토어와 모달 컴포넌트간 의존성을 낮추기 위해  기존의 props 구조를 유지시켰습니다.)
  - [x] fetchWithApi 개선 > 에러 발생시 response 객체를 throw 하도록 수정

### 변경 이유 (Reason for Changes)

* 모달 개선 -> 모달 스토어 사용시 일관성 유지를 위해 상태를 중앙집중화
* fetchWithApi 에서 error response 개선한 이유는, 서버에서 내려주시는 에러 code 접근을 위해선 response  객체에 접근해야하는데 fetch 는 axios 처럼 기본적으로 reponse 접근을 할 수 있게 되어있지 않아서 직접 response 를 throw 시켜버렸습니다.

### 테스트 방법 (Test Procedure)

- 닉네임 수정 (기본적인 유효성 검사, 중복에 대한 에러처리 O)
- 프로필 사진은 일단 삭제만.

### 참고 사항 (Additional Information)

* 너무 길어질 것 같아서 쪼개서 올립니다.
* 프로필 사진은 이미지 파일 업로드 할 수 있게 로직 추가해줘야됌 다음 pr 에 올릴게요
