### PR TITLE
[#111 ] 신고하기 페이지 퍼블리싱, 기능 추가 및 POST API 연결

### DIFF
--- a/src/app/(primary)/report/page.tsx
+++ b/src/app/(primary)/report/page.tsx
@@ -13,7 +13,6 @@ import { FormValues } from '@/types/Report';
 import useModalStore from '@/store/modalStore';
 import Modal from '@/components/Modal';
 import OptionSelect from '@/components/List/OptionSelect';
-import { Storage } from '@/lib/Storage';
 
 // comment, review는 API 나오면 맞춰서 수정 예정
 const REPORT_TYPE = {
@@ -99,6 +98,7 @@ export default function Report() {
   const searchParams = useSearchParams();
   const { state, handleModalState } = useModalStore();
   const type = searchParams.get('type');
+  const reportUserId = searchParams.get('userId');
   const reportTitle = REPORT_TYPE[type as 'review' | 'comment' | 'user'].title;
 
   const schema = yup.object({
@@ -129,6 +129,7 @@ export default function Report() {
   const onSave = async (data: any) => {
     // console.log('save', data);
 
+    // data type은 추후 report API 나오면 맞춰서 함수로 나누기
     try {
       let result;
       if (type === 'user') {
@@ -147,9 +148,6 @@ export default function Report() {
             });
             reset();
             router.back();
-            if (type === 'user') {
-              Storage.removeItem('reportUserId');
-            }
           },
         });
       }
@@ -163,11 +161,13 @@ export default function Report() {
       content: '',
       type: '',
     });
-
-    if (type === 'user') {
-      setValue('reportUserId', Number(Storage.getItem('reportUserId')));
-    }
   }, []);
+
+  useEffect(() => {
+    if (reportUserId) {
+      setValue('reportUserId', Number(reportUserId));
+    }
+  }, [reportUserId]);
 
   useEffect(() => {
     if (errors.content?.message || errors.type?.message) {

--- a/src/app/(primary)/report/page.tsx
+++ b/src/app/(primary)/report/page.tsx
@@ -1,5 +1,247 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect } from 'react';
+import Image from 'next/image';
+import { useRouter, useSearchParams } from 'next/navigation';
+import * as yup from 'yup';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { ReportApi } from '@/app/api/ReportApi';
+import { SubHeader } from '@/app/(primary)/_components/SubHeader';
+import { Button } from '@/components/Button';
+import { FormValues } from '@/types/Report';
+import useModalStore from '@/store/modalStore';
+import Modal from '@/components/Modal';
+import OptionSelect from '@/components/List/OptionSelect';
+import { Storage } from '@/lib/Storage';
+
+// comment, review는 API 나오면 맞춰서 수정 예정
+const REPORT_TYPE = {
+  review: {
+    title: '리뷰 신고',
+    options: [
+      {
+        type: 'SPAM',
+        name: '스팸 신고',
+      },
+      {
+        type: 'INAPPROPRIATE_CONTENT',
+        name: '부적절한 콘텐츠 신고',
+      },
+      {
+        type: 'FRAUD',
+        name: '사기 신고',
+      },
+      {
+        type: 'COPYRIGHT_INFRINGEMENT',
+        name: '저작권 침해 신고',
+      },
+      {
+        type: 'OTHER',
+        name: '그 외 기타 신고',
+      },
+    ],
+  },
+  comment: {
+    title: '댓글 신고',
+    options: [
+      {
+        type: 'SPAM',
+        name: '스팸 신고',
+      },
+      {
+        type: 'INAPPROPRIATE_CONTENT',
+        name: '부적절한 콘텐츠 신고',
+      },
+      {
+        type: 'FRAUD',
+        name: '사기 신고',
+      },
+      {
+        type: 'COPYRIGHT_INFRINGEMENT',
+        name: '저작권 침해 신고',
+      },
+      {
+        type: 'OTHER',
+        name: '그 외 기타 신고',
+      },
+    ],
+  },
+  user: {
+    title: '유저 신고',
+    options: [
+      {
+        type: 'SPAM',
+        name: '스팸 신고',
+      },
+      {
+        type: 'INAPPROPRIATE_CONTENT',
+        name: '부적절한 콘텐츠 신고',
+      },
+      {
+        type: 'FRAUD',
+        name: '사기 신고',
+      },
+      {
+        type: 'COPYRIGHT_INFRINGEMENT',
+        name: '저작권 침해 신고',
+      },
+      {
+        type: 'OTHER',
+        name: '그 외 기타 신고',
+      },
+    ],
+  },
+};
 
 export default function Report() {
-  return <div>Report page</div>;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { state, handleModalState } = useModalStore();
+  const type = searchParams.get('type');
+  const reportTitle = REPORT_TYPE[type as 'review' | 'comment' | 'user'].title;
+
+  const schema = yup.object({
+    content: yup
+      .string()
+      .min(10, '최소 10글자 이상 입력이 필요합니다.')
+      .required('내용을 작성해주세요.'),
+    type: yup.string().required('문의사항을 선택해주세요.'),
+  });
+
+  const userSchema = schema.shape({
+    reportUserId: yup.number().required(),
+  });
+
+  const {
+    handleSubmit,
+    reset,
+    watch,
+    register,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    mode: 'onChange',
+    resolver: yupResolver(type === 'user' ? userSchema : schema), // comment, review는 API 나오면 맞춰서 수정 예정
+  });
+
+  // data type은 추후 report API 나오면 맞춰서 수정 예정
+  const onSave = async (data: any) => {
+    // console.log('save', data);
+
+    try {
+      let result;
+      if (type === 'user') {
+        result = await ReportApi.registerUserReport(data);
+      }
+
+      if (result) {
+        handleModalState({
+          isShowModal: true,
+          type: 'ALERT',
+          mainText: '성공적으로 신고되었습니다.',
+          handleConfirm: () => {
+            handleModalState({
+              isShowModal: false,
+              mainText: '',
+            });
+            reset();
+            router.back();
+            if (type === 'user') {
+              Storage.removeItem('reportUserId');
+            }
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Failed to post report:', error);
+    }
+  };
+
+  useEffect(() => {
+    reset({
+      content: '',
+      type: '',
+    });
+
+    if (type === 'user') {
+      setValue('reportUserId', Number(Storage.getItem('reportUserId')));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (errors.content?.message || errors.type?.message) {
+      handleModalState({
+        isShowModal: true,
+        mainText: errors.content?.message || errors.type?.message,
+        type: 'ALERT',
+      });
+    }
+  }, [errors]);
+
+  return (
+    <>
+      <section className="pb-8 relative">
+        <SubHeader bgColor="bg-bgGray">
+          <SubHeader.Left
+            onClick={() => {
+              if (watch('content')?.length > 0) {
+                handleModalState({
+                  isShowModal: true,
+                  confirmBtnName: '예',
+                  cancelBtnName: '아니요',
+                  mainText: '작성 중인 내용이 있습니다. 정말 나가시겠습니까?',
+                  type: 'CONFIRM',
+                  handleConfirm: () => {
+                    handleModalState({
+                      isShowModal: false,
+                      mainText: '',
+                    });
+                    reset();
+                    router.back();
+                  },
+                });
+              } else router.back();
+            }}
+          >
+            <Image
+              src="/icon/arrow-left-subcoral.svg"
+              alt="arrowIcon"
+              width={23}
+              height={23}
+            />
+          </SubHeader.Left>
+          <SubHeader.Center textColor="text-subCoral">
+            {reportTitle}
+          </SubHeader.Center>
+        </SubHeader>
+        <article className="m-5">
+          <OptionSelect
+            options={REPORT_TYPE[type as 'review' | 'comment' | 'user'].options}
+            title="신고하기"
+            defaultLabel="어떤 문의사항인가요?"
+            handleOptionCallback={(value) => {
+              setValue('type', value);
+            }}
+          />
+        </article>
+        <article className="m-5 border-t-[0.01rem] border-b-[0.01rem] border-mainGray">
+          <textarea
+            placeholder={`${reportTitle} 사유를 작성해주세요.(최소 10자)`}
+            className="w-full h-56 bg-white p-4 text-10 outline-none resize-none text-mainGray"
+            minLength={10}
+            maxLength={1000}
+            {...register('content')}
+          />
+          <div className="text-right text-mainGray text-10 pb-2">
+            ({watch('content')?.length} / 1000)
+          </div>
+        </article>
+        <article className="mx-5 space-y-9">
+          <Button onClick={handleSubmit(onSave)} btnName="전송" />
+        </article>
+      </section>
+      {state.isShowModal && <Modal />}
+    </>
+  );
 }

--- a/src/app/(primary)/review/[id]/_components/Reply/Reply.tsx
+++ b/src/app/(primary)/review/[id]/_components/Reply/Reply.tsx
@@ -14,7 +14,6 @@ import { RootReply, SubReply } from '@/types/Reply';
 import useModalStore from '@/store/modalStore';
 import Modal from '@/components/Modal';
 import { AuthService } from '@/lib/AuthService';
-import { Storage } from '@/lib/Storage';
 import userImg from 'public/user_img.png';
 
 interface Props {
@@ -107,10 +106,7 @@ function Reply({
         mainText: '준비 중인 기능입니다.',
       });
     } else if (option.type === 'USER_REPORT') {
-      router.push(`/report?type=user`);
-      if (data.userId !== undefined) {
-        Storage.setItem('reportUserId', data.userId.toString());
-      }
+      router.push(`/report?type=user&userId=${data.userId}`);
     }
   };
 

--- a/src/app/(primary)/review/[id]/_components/Reply/Reply.tsx
+++ b/src/app/(primary)/review/[id]/_components/Reply/Reply.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useFormContext } from 'react-hook-form';
 import { ReplyApi } from '@/app/api/ReplyApi';
 import { truncStr } from '@/utils/truncStr';
@@ -13,6 +14,7 @@ import { RootReply, SubReply } from '@/types/Reply';
 import useModalStore from '@/store/modalStore';
 import Modal from '@/components/Modal';
 import { AuthService } from '@/lib/AuthService';
+import { Storage } from '@/lib/Storage';
 import userImg from 'public/user_img.png';
 
 interface Props {
@@ -36,6 +38,7 @@ function Reply({
   isSubReplyShow = false,
   resetSubReplyToggle,
 }: Props) {
+  const router = useRouter();
   const { isLogin, userData } = AuthService;
   const { setValue } = useFormContext();
   const { state, handleModalState, handleLoginModal } = useModalStore();
@@ -96,16 +99,18 @@ function Reply({
           deleteReply();
         },
       });
-    } else if (option.type === 'REPORT') {
+    } else if (option.type === 'REVIEW_REPORT') {
+      // router.push(`/report?type=review`);
+      // API 준비 안됨
       handleModalState({
         isShowModal: true,
         mainText: '준비 중인 기능입니다.',
       });
     } else if (option.type === 'USER_REPORT') {
-      handleModalState({
-        isShowModal: true,
-        mainText: '준비 중인 기능입니다.',
-      });
+      router.push(`/report?type=user`);
+      if (data.userId !== undefined) {
+        Storage.setItem('reportUserId', data.userId.toString());
+      }
     }
   };
 
@@ -209,7 +214,7 @@ function Reply({
                   { name: '삭제하기', type: 'DELETE' },
                 ]
               : [
-                  { name: '리뷰 신고', type: 'REPORT' },
+                  { name: '리뷰 신고', type: 'REVIEW_REPORT' },
                   { name: '유저 신고', type: 'USER_REPORT' },
                 ]
           }

--- a/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
+++ b/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
@@ -16,7 +16,6 @@ import useModalStore from '@/store/modalStore';
 import { ReviewDetailsWithoutAlcoholInfo } from '@/types/Review';
 import { deleteReview } from '@/lib/Review';
 import { AuthService } from '@/lib/AuthService';
-import { Storage } from '@/lib/Storage';
 import ProfileDefaultImg from 'public/profile-default.svg';
 
 interface Props {
@@ -68,10 +67,7 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
         mainText: '준비 중인 기능입니다.',
       });
     } else if (option.type === 'USER_REPORT') {
-      router.push(`/report?type=user`);
-      if (data.reviewResponse?.userId !== undefined) {
-        Storage.setItem('reportUserId', data.reviewResponse?.userId.toString());
-      }
+      router.push(`/report?type=user&userId=${data.reviewResponse?.userId}`);
     }
   };
 

--- a/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
+++ b/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
@@ -16,6 +16,7 @@ import useModalStore from '@/store/modalStore';
 import { ReviewDetailsWithoutAlcoholInfo } from '@/types/Review';
 import { deleteReview } from '@/lib/Review';
 import { AuthService } from '@/lib/AuthService';
+import { Storage } from '@/lib/Storage';
 import ProfileDefaultImg from 'public/profile-default.svg';
 
 interface Props {
@@ -59,16 +60,18 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
       });
     } else if (option.type === 'MODIFY') {
       router.push(`/review/modify?reviewId=${data.reviewResponse?.reviewId}`);
-    } else if (option.type === 'REPORT') {
+    } else if (option.type === 'REVIEW_REPORT') {
+      // router.push(`/report?type=review`);
+      // API 준비 안됨
       handleModalState({
         isShowModal: true,
         mainText: '준비 중인 기능입니다.',
       });
     } else if (option.type === 'USER_REPORT') {
-      handleModalState({
-        isShowModal: true,
-        mainText: '준비 중인 기능입니다.',
-      });
+      router.push(`/report?type=user`);
+      if (data.reviewResponse?.userId !== undefined) {
+        Storage.setItem('reportUserId', data.reviewResponse?.userId.toString());
+      }
     }
   };
 
@@ -216,13 +219,7 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
                     <br />
                     {data.reviewResponse?.mapUrl && (
                       <p className="text-10 text-subCoral m-0 p-0">
-                        <Link
-                          href={data.reviewResponse.mapUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          지도보기
-                        </Link>
+                        <Link href={data.reviewResponse.mapUrl}>지도보기</Link>
                       </p>
                     )}
                   </>
@@ -303,7 +300,7 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
                   { name: '삭제하기', type: 'DELETE' },
                 ]
               : [
-                  { name: '리뷰 신고', type: 'REPORT' },
+                  { name: '리뷰 신고', type: 'REVIEW_REPORT' },
                   { name: '유저 신고', type: 'USER_REPORT' },
                 ]
           }

--- a/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
@@ -17,7 +17,6 @@ import Modal from '@/components/Modal';
 import useModalStore from '@/store/modalStore';
 import { deleteReview } from '@/lib/Review';
 import { AuthService } from '@/lib/AuthService';
-import { Storage } from '@/lib/Storage';
 import userImg from 'public/user_img.png';
 
 interface Props {
@@ -68,10 +67,7 @@ function Review({ data }: Props) {
         mainText: '준비 중인 기능입니다.',
       });
     } else if (option.type === 'USER_REPORT') {
-      router.push(`/report?type=user`);
-      if (data.userId !== undefined) {
-        Storage.setItem('reportUserId', data.userId.toString());
-      }
+      router.push(`/report?type=user&userId=${data.userId}`);
     }
   };
 

--- a/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
@@ -13,10 +13,11 @@ import { formatDate } from '@/utils/formatDate';
 import VisibilityToggle from '@/app/(primary)/_components/VisibilityToggle';
 import LikeBtn from '@/app/(primary)/_components/LikeBtn';
 import OptionDropdown from '@/components/OptionDropdown';
+import Modal from '@/components/Modal';
 import useModalStore from '@/store/modalStore';
 import { deleteReview } from '@/lib/Review';
-import Modal from '@/components/Modal';
 import { AuthService } from '@/lib/AuthService';
+import { Storage } from '@/lib/Storage';
 import userImg from 'public/user_img.png';
 
 interface Props {
@@ -25,7 +26,7 @@ interface Props {
 
 function Review({ data }: Props) {
   const router = useRouter();
-  const { isLogin, userData } = AuthService;
+  const { userData, isLogin } = AuthService;
   const { isLikedByMe } = data;
   const { state, handleModalState, handleLoginModal } = useModalStore();
   const [isOptionShow, setIsOptionShow] = useState(false);
@@ -59,16 +60,18 @@ function Review({ data }: Props) {
       });
     } else if (option.type === 'MODIFY') {
       router.push(`/review/modify?reviewId=${data.reviewId}`);
-    } else if (option.type === 'REPORT') {
+    } else if (option.type === 'REVIEW_REPORT') {
+      // router.push(`/report?type=review`);
+      // API 준비 안됨
       handleModalState({
         isShowModal: true,
         mainText: '준비 중인 기능입니다.',
       });
     } else if (option.type === 'USER_REPORT') {
-      handleModalState({
-        isShowModal: true,
-        mainText: '준비 중인 기능입니다.',
-      });
+      router.push(`/report?type=user`);
+      if (data.userId !== undefined) {
+        Storage.setItem('reportUserId', data.userId.toString());
+      }
     }
   };
 
@@ -138,6 +141,7 @@ function Review({ data }: Props) {
               )}
             </Link>
           </p>
+          {/* 없을 때 이미지 안나오게 수정 */}
           <div className="flex justify-end items-center">
             <Image
               className="w-[3.8rem] h-[3.8rem]"
@@ -213,7 +217,7 @@ function Review({ data }: Props) {
                   { name: '삭제하기', type: 'DELETE' },
                 ]
               : [
-                  { name: '리뷰 신고', type: 'REPORT' },
+                  { name: '리뷰 신고', type: 'REVIEW_REPORT' },
                   { name: '유저 신고', type: 'USER_REPORT' },
                 ]
           }

--- a/src/app/api/ReportApi.ts
+++ b/src/app/api/ReportApi.ts
@@ -1,0 +1,19 @@
+import { ApiResponse } from '@/types/common';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
+import { ReportPostApi, UserReportQueryParams } from '@/types/Report';
+
+export const ReportApi = {
+  async registerUserReport(params: UserReportQueryParams) {
+    const response = await fetchWithAuth(`/bottle-api/reports/user`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+
+    if (response.errors.length !== 0) {
+      throw new Error('Failed to fetch data');
+    }
+
+    const result: ApiResponse<ReportPostApi> = await response;
+    return result.data;
+  },
+};

--- a/src/components/List/OptionSelect.tsx
+++ b/src/components/List/OptionSelect.tsx
@@ -7,14 +7,18 @@ interface SortOptionProps {
   options: { type: string; name: string }[];
   handleOptionCallback?: (type: string) => void;
   title?: string;
+  defaultLabel?: string;
 }
 
 const OptionSelect = ({
   options,
   handleOptionCallback,
   title,
+  defaultLabel,
 }: SortOptionProps) => {
-  const [selectedOption, setSelectedOption] = useState(options[0].name);
+  const [selectedOption, setSelectedOption] = useState(
+    defaultLabel || options[0].name,
+  );
   const [isDropDownShow, setIsDropDownShow] = useState(false);
 
   const handleSortOptionsShow = () => {

--- a/src/types/Report.ts
+++ b/src/types/Report.ts
@@ -1,0 +1,19 @@
+export interface Report {
+  content: string;
+  type: string;
+}
+
+export interface FormValues extends Report {
+  reportUserId?: number;
+}
+
+export interface UserReportQueryParams extends Report {
+  reportUserId: number;
+}
+
+export interface ReportPostApi {
+  reportUserId: number;
+  message: string;
+  reportId: number;
+  reportUserName: string;
+}


### PR DESCRIPTION
### PR 제목 (Title)

*  [#111 ] 신고하기 페이지 퍼블리싱, 기능 추가 및 POST API 연결

### 변경 사항 (Changes)

- [x] 신고하기 페이지 퍼블리싱 및 기능 추가
- [x] 각 페이지별 '유저 신고' 버튼 router 수정
- [x] user 신고하기 POST API 연결

### 테스트 방법 (Test Procedure)

리뷰, 댓글 등에서 '유저 신고' 버튼을 통해 페이지 이동 후 테스트 가능

### 참고 사항 (Additional Information)
* OptionSelect 컴포넌트에 값이 없는 기본 라벨값이 필요해서 추가 했습니다.
* router를 이용해서 url 쿼리에 안보여주고 이동하는 페이지로 값을 넘겨주는 방식이 없어진 것 같아서 신고하고 싶은 userId를 스토리지에 저장하는 방향으로 했는데 더 좋은 방법이 있으면 댓글 부탁드려요!
* 리뷰, 댓글 신고에 대한 분기가 추가적으로 필요한데 기획과 api가 없어서 추후 수정이 필요합니다.
* 이번주는 문의하기 작업 예정입니다.
* 추가적으로 기본적인 작업이 끝나면 회원만 접근이 가능한 페이지는 url 입력으로 접근했을 때 리다이렉트 되는 로직이 전체적으로 추가되야 할 것 같아요!