### PR TITLE
[#176] 리프레시 토큰 갱신 안됨 이슈

### DIFF
--- a/src/app/(primary)/layout.tsx
+++ b/src/app/(primary)/layout.tsx
@@ -9,6 +9,7 @@ export default function Layout({
   children: React.ReactNode;
 }>) {
   const { loginState, handleLoginModal } = useModalStore();
+
   return (
     <main className="bg-white flex flex-col w-full mx-auto max-w-[430px] min-h-screen">
       <section className="flex-1 overflow-y-auto">{children}</section>

--- a/src/app/api/token/renew/route.ts
+++ b/src/app/api/token/renew/route.ts
@@ -1,20 +1,56 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { AuthApi } from '../../AuthApi';
 
-export async function POST(req: NextRequest, res: NextResponse) {
-  const refreshToken = await req.json();
-
+export async function POST(req: NextRequest) {
   try {
-    const newTokens = await AuthApi.renewAccessToken(refreshToken);
+    const { refreshToken } = await req.json();
+
+    if (!refreshToken) {
+      return NextResponse.json(
+        { error: '리프레시 토큰이 존재하지 않습니다.' },
+        { status: 400 },
+      );
+    }
+
+    // 토큰 갱신 요청
+    const response = await fetch(`${process.env.SERVER_URL}/oauth/reissue`, {
+      method: 'POST',
+      headers: {
+        'refresh-token': refreshToken,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.json();
+      return NextResponse.json(
+        { error: `HTTP error! message: ${body.errors.message}` },
+        { status: response.status },
+      );
+    }
+
+    // 새 리프레시 토큰 파싱
+    const cookie: string = response.headers.getSetCookie()[0] ?? '';
+    const newRefreshToken = (
+      cookie
+        .split(';')
+        .find((item) => item.trim().startsWith('refresh-token=')) as string
+    ).split('=')[1];
+
+    const { data } = await response.json();
 
     return NextResponse.json(
-      { res, data: newTokens },
       {
-        status: 200,
+        data: { accessToken: data.accessToken, refreshToken: newRefreshToken },
       },
+      { status: 200 },
     );
-  } catch (e) {
-    console.error(e);
-    return NextResponse.json({ error: e }, { status: 500 });
+  } catch (error) {
+    console.error(
+      `토큰 업데이트 도중 에러가 발생했습니다. 사유: ${(error as Error).message}`,
+    );
+    return NextResponse.json(
+      { error: `토큰 업데이트 도중 에러가 발생했습니다.` },
+      { status: 500 },
+    );
   }
 }

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -24,6 +24,7 @@ interface ModalStore {
   state: ModalState;
   loginState: LoginModalState;
   handleModalState: (state: ParcialModalState) => void;
+  handleLoginState: (state: boolean) => void;
   handleCloseModal: () => void;
   handleLoginModal: () => void;
 }
@@ -43,6 +44,8 @@ const useModalStore = create<ModalStore>((set) => ({
   loginState: {
     isShowLoginModal: false,
   },
+  handleLoginState: (newState) =>
+    set({ loginState: { isShowLoginModal: newState } }),
   handleModalState: (newState) =>
     set((state) => ({
       state: {

--- a/src/utils/fetchWithAuth.ts
+++ b/src/utils/fetchWithAuth.ts
@@ -1,4 +1,5 @@
 import { AuthApi } from '@/app/api/AuthApi';
+import useModalStore from '@/store/modalStore';
 import { ApiError } from './ApiError';
 import { AuthService } from '../lib/AuthService';
 
@@ -15,7 +16,11 @@ export const fetchWithAuth: FetchWithAuth = async (
 ) => {
   const token = AuthService.getToken();
 
-  if (!token) throw new Error('No token');
+  if (!token) {
+    AuthService.logout();
+    const { handleLoginState } = useModalStore.getState();
+    return handleLoginState(true);
+  }
 
   const defaultOptions = {
     ...options,


### PR DESCRIPTION
### PR 제목 (Title)

*  #176 

### 변경 사항 (Changes)

* 체크리스트
  - [x] 리프레시 토큰 만료시 로그인 모달 띄우도록 로직 추가

### 변경 이유 (Reason for Changes)

* 로그인 모달 띄우는 처리가 토큰은 있지만 만료된 경우에도 추가되어야 하는데 그렇지 않았음

### 테스트 방법 (Test Procedure)

* 로그인 후 리프레시 토큰 만료될 때까지 기다렸다가 체크

### 참고 사항 (Additional Information)

- api 요청을 쐈을 때 토큰이 만료되었으면 403으로 와야되는데 400으로 오는 케이스의 경우 현재 로직에 걸리지 않음
  - 예를 들어 어떤 경우 액세스 토큰 만료시에 403이 아닌 400으로 상태코드가 날아오는 경우가 있는데 이 경우 정상 처리가 안되기 때문에 백엔드쪽과 조정 필요
- 다른 방식으로 에러처리가 되어 있는 경우 겹칠 수 있음 
  - pick 버튼의 경우 에러가 발생하면 별도 모달을 띄워주도록 되어있는데 이 부분이 두 개의 모달이 겹치는 현상으로 발생