### PR TITLE
[#190] API 응답 처리 전 중복 요청 방지 로직 구현 및 review 리팩토링

### DIFF
--- a/src/app/(custom)/layout.tsx
+++ b/src/app/(custom)/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="bg-white flex flex-col w-full mx-auto min-h-screen">
+    <div className="flex flex-col w-full mx-auto min-h-screen py-12 bg-subCoral">
       <main className="flex-1 overflow-y-auto">{children}</main>
     </div>
   );

--- a/src/app/(primary)/_components/Header.tsx
+++ b/src/app/(primary)/_components/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
   });
 
   return (
-    <div className="py-[1.3rem] px-5 space-y-4 bg-subCoral">
+    <div className="py-[1.3rem] px-5 space-y-4 bg-subCoral pt-12">
       <div
         className={`transition-opacity duration-500 ease-in-out flex items-center space-x-1 ${
           scrollPosition > 0 ? 'opacity-0 delay-150' : 'opacity-100'

--- a/src/app/(primary)/_components/SubHeader.tsx
+++ b/src/app/(primary)/_components/SubHeader.tsx
@@ -51,7 +51,7 @@ interface SubHeaderMainProps {
 function SubHeaderMain({ children, bgColor }: SubHeaderMainProps) {
   return (
     <div
-      className={`${bgColor} flex justify-between items-center relative py-8 px-5`}
+      className={`${bgColor} flex justify-between items-center relative pb-8 px-5 pt-20`}
     >
       {children}
     </div>

--- a/src/app/(primary)/inquire/register/page.tsx
+++ b/src/app/(primary)/inquire/register/page.tsx
@@ -12,7 +12,7 @@ import { Button } from '@/components/Button';
 import { uploadImages } from '@/utils/S3Upload';
 import { FormValues } from '@/types/Inquire';
 import useModalStore from '@/store/modalStore';
-import { useSingleCall } from '@/hooks/useCallOnce';
+import { useCallOnce } from '@/hooks/useCallOnce';
 import Modal from '@/components/Modal';
 import { useErrorModal } from '@/hooks/useErrorModal';
 import OptionSelect from '@/components/List/OptionSelect';
@@ -41,7 +41,7 @@ const TYPE_OPTIONS = [
 export default function InquireRegister() {
   const router = useRouter();
   const { state, handleModalState } = useModalStore();
-  const { isProcessing, executeApiCall } = useSingleCall();
+  const { isProcessing, executeApiCall } = useCallOnce();
 
   const schema = yup.object({
     content: yup

--- a/src/app/(primary)/inquire/register/page.tsx
+++ b/src/app/(primary)/inquire/register/page.tsx
@@ -12,8 +12,11 @@ import { Button } from '@/components/Button';
 import { uploadImages } from '@/utils/S3Upload';
 import { FormValues } from '@/types/Inquire';
 import useModalStore from '@/store/modalStore';
+import { useSingleCall } from '@/hooks/useCallOnce';
 import Modal from '@/components/Modal';
+import { useErrorModal } from '@/hooks/useErrorModal';
 import OptionSelect from '@/components/List/OptionSelect';
+import Loading from '@/components/Loading';
 import ImagesForm from '../../review/_components/ImagesForm';
 
 const TYPE_OPTIONS = [
@@ -38,6 +41,7 @@ const TYPE_OPTIONS = [
 export default function InquireRegister() {
   const router = useRouter();
   const { state, handleModalState } = useModalStore();
+  const { isProcessing, executeApiCall } = useSingleCall();
 
   const schema = yup.object({
     content: yup
@@ -50,6 +54,12 @@ export default function InquireRegister() {
   const formMethods = useForm<FormValues>({
     mode: 'onChange',
     resolver: yupResolver(schema),
+    defaultValues: {
+      content: '',
+      type: '',
+      images: null,
+      imageUrlList: null,
+    },
   });
 
   const {
@@ -61,17 +71,27 @@ export default function InquireRegister() {
     formState: { errors },
   } = formMethods;
 
-  const onSubmit = async (
-    data: FormValues,
-    imgUrl?: { order: number; viewUrl: string }[],
-  ) => {
-    const params = {
-      content: data.content,
-      type: data.type,
-      imageUrlList: imgUrl ?? null,
-    };
+  const onSave = async (data: FormValues) => {
+    const processSubmission = async () => {
+      let uploadedImageUrls = null;
+      if (data.images?.length !== 0) {
+        const images = data?.images?.map((file) => file.image);
+        if (images) {
+          try {
+            uploadedImageUrls = await uploadImages('inquire', images);
+          } catch (error) {
+            console.error('S3 업로드 에러:', error);
+            throw error;
+          }
+        }
+      }
 
-    try {
+      const params = {
+        content: data.content,
+        type: data.type,
+        imageUrlList: uploadedImageUrls ?? null,
+      };
+
       const result = await InquireApi.registerInquire(params);
 
       if (result) {
@@ -89,49 +109,15 @@ export default function InquireRegister() {
           },
         });
       }
-    } catch (error) {
-      console.error('Failed to post report:', error);
-    }
+    };
+
+    await executeApiCall(processSubmission);
   };
 
-  const onUploadS3 = async (data: FormValues) => {
-    const images = data?.images?.map((file) => file.image);
-
-    if (images) {
-      try {
-        const PreSignedDBData = await uploadImages('inquire', images);
-        onSubmit(data, PreSignedDBData);
-      } catch (error) {
-        console.error('S3 업로드 에러:', error);
-      }
-    }
-  };
-
-  const onSave = (data: FormValues) => {
-    if (data.images?.length !== 0) {
-      onUploadS3(data);
-    } else {
-      onSubmit(data);
-    }
-  };
+  const { showErrorModal } = useErrorModal<FormValues>(errors);
 
   useEffect(() => {
-    reset({
-      content: '',
-      type: '',
-      images: null,
-      imageUrlList: null,
-    });
-  }, []);
-
-  useEffect(() => {
-    if (errors.content?.message || errors.type?.message) {
-      handleModalState({
-        isShowModal: true,
-        mainText: errors.content?.message || errors.type?.message,
-        type: 'ALERT',
-      });
-    }
+    showErrorModal(['content', 'type']);
   }, [errors]);
 
   return (
@@ -200,6 +186,7 @@ export default function InquireRegister() {
             <Button onClick={handleSubmit(onSave)} btnName="전송" />
           </article>
         </section>
+        {isProcessing && <Loading />}
         {state.isShowModal && <Modal />}
       </FormProvider>
     </>

--- a/src/app/(primary)/layout.tsx
+++ b/src/app/(primary)/layout.tsx
@@ -11,11 +11,11 @@ export default function Layout({
   const { loginState, handleLoginModal } = useModalStore();
 
   return (
-    <main className="bg-white flex flex-col w-full mx-auto min-h-screen">
-      <section className="flex-1 overflow-y-auto">{children}</section>
+    <div className="bg-white flex flex-col w-full mx-auto min-h-screen pb-12">
+      <main className="flex-1 overflow-y-auto">{children}</main>
       {loginState.isShowLoginModal && (
         <LoginModal handleClose={handleLoginModal} />
       )}
-    </main>
+    </div>
   );
 }

--- a/src/app/(primary)/rating/page.tsx
+++ b/src/app/(primary)/rating/page.tsx
@@ -84,7 +84,7 @@ export default function Rating() {
       <main className="mb-24 w-full h-full relative">
         <SearchContainer
           handleSearchCallback={handleSearchCallback}
-          styleProps="px-5 py-10 bg-subCoral"
+          styleProps="px-5 pt-[5.5rem] pb-10 bg-subCoral"
         />
 
         <section className="flex flex-col gap-7 p-5">

--- a/src/app/(primary)/report/_constants/index.ts
+++ b/src/app/(primary)/report/_constants/index.ts
@@ -1,0 +1,78 @@
+// comment, review는 API 나오면 맞춰서 수정 예정
+export const REPORT_TYPE = {
+  review: {
+    title: '리뷰 신고',
+    options: [
+      {
+        type: 'SPAM',
+        name: '스팸 신고',
+      },
+      {
+        type: 'INAPPROPRIATE_CONTENT',
+        name: '부적절한 콘텐츠 신고',
+      },
+      {
+        type: 'FRAUD',
+        name: '사기 신고',
+      },
+      {
+        type: 'COPYRIGHT_INFRINGEMENT',
+        name: '저작권 침해 신고',
+      },
+      {
+        type: 'OTHER',
+        name: '그 외 기타 신고',
+      },
+    ],
+  },
+  comment: {
+    title: '댓글 신고',
+    options: [
+      {
+        type: 'SPAM',
+        name: '스팸 신고',
+      },
+      {
+        type: 'INAPPROPRIATE_CONTENT',
+        name: '부적절한 콘텐츠 신고',
+      },
+      {
+        type: 'FRAUD',
+        name: '사기 신고',
+      },
+      {
+        type: 'COPYRIGHT_INFRINGEMENT',
+        name: '저작권 침해 신고',
+      },
+      {
+        type: 'OTHER',
+        name: '그 외 기타 신고',
+      },
+    ],
+  },
+  user: {
+    title: '유저 신고',
+    options: [
+      {
+        type: 'SPAM',
+        name: '스팸 신고',
+      },
+      {
+        type: 'INAPPROPRIATE_CONTENT',
+        name: '부적절한 콘텐츠 신고',
+      },
+      {
+        type: 'FRAUD',
+        name: '사기 신고',
+      },
+      {
+        type: 'COPYRIGHT_INFRINGEMENT',
+        name: '저작권 침해 신고',
+      },
+      {
+        type: 'OTHER',
+        name: '그 외 기타 신고',
+      },
+    ],
+  },
+};

--- a/src/app/(primary)/report/page.tsx
+++ b/src/app/(primary)/report/page.tsx
@@ -10,7 +10,7 @@ import { ReportApi } from '@/app/api/ReportApi';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
 import { Button } from '@/components/Button';
 import { FormValues } from '@/types/Report';
-import { useSingleCall } from '@/hooks/useCallOnce';
+import { useCallOnce } from '@/hooks/useCallOnce';
 import { useErrorModal } from '@/hooks/useErrorModal';
 import useModalStore from '@/store/modalStore';
 import Modal from '@/components/Modal';
@@ -22,7 +22,7 @@ export default function Report() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { state, handleModalState } = useModalStore();
-  const { isProcessing, executeApiCall } = useSingleCall();
+  const { isProcessing, executeApiCall } = useCallOnce();
 
   const type = searchParams.get('type');
   const reportUserId = searchParams.get('userId');

--- a/src/app/(primary)/review/_components/TagsForm.tsx
+++ b/src/app/(primary)/review/_components/TagsForm.tsx
@@ -22,9 +22,11 @@ export default function TagsForm({ korName }: Props) {
   const [tags, setTags] = useState<string[]>([]);
   const [isAdding, setIsAdding] = useState(false);
 
+  const watchTags = watch('flavor_tags');
+
   useEffect(() => {
-    setTags(watch('flavor_tags'));
-  }, [watch('flavor_tags')]);
+    if (watchTags && watchTags.length !== 0) setTags(watchTags);
+  }, [watchTags]);
 
   return (
     <>

--- a/src/app/(primary)/review/_schemas/reviewFormSchema.ts
+++ b/src/app/(primary)/review/_schemas/reviewFormSchema.ts
@@ -1,0 +1,20 @@
+import * as yup from 'yup';
+
+export const reviewSchema = yup.object({
+  review: yup.string().required('리뷰 내용을 작성해주세요.'),
+  status: yup.string().required(),
+  price: yup.number().nullable(),
+  price_type: yup
+    .string()
+    .nullable()
+    .transform((value) => (value === '' ? null : value))
+    .when('price', {
+      is: (price: number | null) => price !== null && price > 0,
+      then: (schemaOne) =>
+        schemaOne
+          .oneOf(['GLASS', 'BOTTLE'] as const)
+          .required('가격 타입을 선택해주세요.'),
+      otherwise: (schemaTwo) =>
+        schemaTwo.oneOf(['GLASS', 'BOTTLE', null] as const).nullable(),
+    }),
+});

--- a/src/app/(primary)/review/modify/page.tsx
+++ b/src/app/(primary)/review/modify/page.tsx
@@ -12,7 +12,7 @@ import { FormValues } from '@/types/Review';
 import { ReviewApi } from '@/app/api/ReviewApi';
 import { RateApi } from '@/app/api/RateApi';
 import { uploadImages } from '@/utils/S3Upload';
-import { useSingleCall } from '@/hooks/useCallOnce';
+import { useCallOnce } from '@/hooks/useCallOnce';
 import { useAlcoholDetails } from '@/hooks/useAlcoholDetails';
 import { useErrorModal } from '@/hooks/useErrorModal';
 import { reviewSchema } from '@/app/(primary)/review/_schemas/reviewFormSchema';
@@ -25,7 +25,7 @@ import ReviewForm from '../_components/ReviewForm';
 function ReviewModify() {
   const router = useRouter();
   const { state, handleModalState } = useModalStore();
-  const { isProcessing, executeApiCall } = useSingleCall();
+  const { isProcessing, executeApiCall } = useCallOnce();
   const searchParams = useSearchParams();
   const reviewId = searchParams.get('reviewId');
   const [alcoholId, setAlcoholId] = useState<string>('');

--- a/src/app/(primary)/review/register/page.tsx
+++ b/src/app/(primary)/review/register/page.tsx
@@ -15,7 +15,7 @@ import { reviewSchema } from '@/app/(primary)/review/_schemas/reviewFormSchema';
 import { uploadImages } from '@/utils/S3Upload';
 import { Button } from '@/components/Button';
 import Loading from '@/components/Loading';
-import { useSingleCall } from '@/hooks/useCallOnce';
+import { useCallOnce } from '@/hooks/useCallOnce';
 import { useAlcoholDetails } from '@/hooks/useAlcoholDetails';
 import { useErrorModal } from '@/hooks/useErrorModal';
 import useModalStore from '@/store/modalStore';
@@ -26,7 +26,7 @@ function ReviewRegister() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { state, handleModalState } = useModalStore();
-  const { isProcessing, executeApiCall } = useSingleCall();
+  const { isProcessing, executeApiCall } = useCallOnce();
   const alcoholId = searchParams.get('alcoholId') || '';
   const {
     alcoholData,

--- a/src/app/(primary)/review/register/page.tsx
+++ b/src/app/(primary)/review/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useForm, FormProvider } from 'react-hook-form';
@@ -8,13 +8,16 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
 import AlcoholInfo from '@/app/(primary)/review/_components/AlcoholInfo';
-import { AlcoholsApi } from '@/app/api/AlcholsApi';
-import { AlcoholInfo as AlcoholDetails } from '@/types/Alcohol';
 import { FormValues } from '@/types/Review';
 import { ReviewApi } from '@/app/api/ReviewApi';
 import { RateApi } from '@/app/api/RateApi';
+import { reviewSchema } from '@/app/(primary)/review/_schemas/reviewFormSchema';
 import { uploadImages } from '@/utils/S3Upload';
 import { Button } from '@/components/Button';
+import Loading from '@/components/Loading';
+import { useSingleCall } from '@/hooks/useCallOnce';
+import { useAlcoholDetails } from '@/hooks/useAlcoholDetails';
+import { useErrorModal } from '@/hooks/useErrorModal';
 import useModalStore from '@/store/modalStore';
 import Modal from '@/components/Modal';
 import ReviewForm from '../_components/ReviewForm';
@@ -23,32 +26,17 @@ function ReviewRegister() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { state, handleModalState } = useModalStore();
+  const { isProcessing, executeApiCall } = useSingleCall();
   const alcoholId = searchParams.get('alcoholId') || '';
-  const [alcoholData, setAlcoholData] = useState<AlcoholDetails | null>();
-  const [initialRating, setInitialRating] = useState<number>(0);
-
-  const schema = yup.object({
-    review: yup.string().required('리뷰 내용을 작성해주세요.'),
-    status: yup.string().required(),
-    price: yup.number().nullable(),
-    price_type: yup
-      .string()
-      .nullable()
-      .transform((value) => (value === '' ? null : value))
-      .when('price', {
-        is: (price: number | null) => price !== null && price > 0,
-        then: (schemaOne) =>
-          schemaOne
-            .oneOf(['GLASS', 'BOTTLE'] as const)
-            .required('가격 타입을 선택해주세요.'),
-        otherwise: (schemaTwo) =>
-          schemaTwo.oneOf(['GLASS', 'BOTTLE', null] as const).nullable(),
-      }),
-  }) as yup.ObjectSchema<FormValues>;
+  const {
+    alcoholData,
+    userRating,
+    isLoading: isAlcoholLoading,
+  } = useAlcoholDetails(alcoholId);
 
   const formMethods = useForm<FormValues>({
     mode: 'onChange',
-    resolver: yupResolver(schema),
+    resolver: yupResolver(reviewSchema as yup.ObjectSchema<FormValues>),
     defaultValues: {
       review: '',
       status: 'PUBLIC',
@@ -75,118 +63,98 @@ function ReviewRegister() {
     formState: { isDirty, errors },
   } = formMethods;
 
-  const onSubmit = async (
-    data: FormValues,
-    imgUrl?: { order: number; viewUrl: string }[],
-  ) => {
-    // 별점 POST api
-    const ratingParams = {
-      alcoholId,
-      rating: data.rating ?? 0,
-    };
-    // 리뷰 POST api
-    const reviewParams = {
-      alcoholId,
-      status: data.status,
-      content: data.review,
-      sizeType: data.price ? data.price_type : null,
-      price: data.price,
-      imageUrlList: imgUrl ?? null,
-      tastingTagList: data.flavor_tags,
-      locationInfo: {
-        locationName: data.locationName,
-        zipCode: data.zipCode,
-        address: data.address,
-        detailAddress: data.detailAddress,
-        category: data.category,
-        mapUrl: data.mapUrl,
-        latitude: data.latitude,
-        longitude: data.longitude,
-      },
-      rating: data.rating ?? 0,
-    };
-
-    let ratingResult = null;
-    if (initialRating !== data.rating) {
-      ratingResult = await RateApi.postRating(ratingParams);
-    }
-    const reviewResult = await ReviewApi.registerReview(reviewParams);
-
-    // error에 대해 추후 보완 예정
-    if (
-      (initialRating !== data.rating && ratingResult && reviewResult) ||
-      (initialRating === data.rating && reviewResult) ||
-      (initialRating !== data.rating && reviewResult && !ratingResult)
-    ) {
-      const text =
-        initialRating !== data.rating && !ratingResult
-          ? '❗️별점 등록에는 실패했습니다. 다시 시도해주세요.'
-          : '여정에 한발 더 가까워지셨어요!';
-      handleModalState({
-        isShowModal: true,
-        mainText: '작성을 완료했습니다 👍',
-        subText: text,
-        type: 'ALERT',
-        handleConfirm: () => {
-          router.push(`/review/${reviewResult.id}`);
-          handleModalState({
-            isShowModal: false,
-            mainText: '',
-          });
-        },
-      });
-    } else if (initialRating !== data.rating && ratingResult && !reviewResult) {
-      // alert('리뷰는 등록되지 않았습니다.');
-      router.back();
-    }
-  };
-
-  const onUploadS3 = async (data: FormValues) => {
-    const images = data?.images?.map((file) => file.image);
-
-    if (images) {
-      try {
-        const PreSignedDBData = await uploadImages('review', images);
-        onSubmit(data, PreSignedDBData);
-      } catch (error) {
-        console.error('S3 업로드 에러:', error);
+  const onSave = async (data: FormValues) => {
+    const processSubmission = async () => {
+      let uploadedImageUrls = null;
+      if (data.images?.length !== 0) {
+        const images = data?.images?.map((file) => file.image);
+        if (images) {
+          try {
+            uploadedImageUrls = await uploadImages('review', images);
+          } catch (error) {
+            console.error('S3 업로드 에러:', error);
+            throw error;
+          }
+        }
       }
-    }
-  };
 
-  const onSave = (data: FormValues) => {
-    // console.log('data1', data);
-    if (data.images?.length !== 0) {
-      onUploadS3(data);
-    } else {
-      onSubmit(data);
-    }
+      const ratingParams = {
+        alcoholId,
+        rating: data.rating ?? 0,
+      };
+
+      const reviewParams = {
+        alcoholId,
+        status: data.status,
+        content: data.review,
+        sizeType: data.price ? data.price_type : null,
+        price: data.price,
+        imageUrlList: uploadedImageUrls ?? null,
+        tastingTagList: data.flavor_tags,
+        locationInfo: {
+          locationName: data.locationName,
+          zipCode: data.zipCode,
+          address: data.address,
+          detailAddress: data.detailAddress,
+          category: data.category,
+          mapUrl: data.mapUrl,
+          latitude: data.latitude,
+          longitude: data.longitude,
+        },
+        rating: data.rating ?? 0,
+      };
+
+      let ratingResult = null;
+      if (userRating !== data.rating) {
+        ratingResult = await RateApi.postRating(ratingParams);
+      }
+
+      const reviewResult = await ReviewApi.registerReview(reviewParams);
+
+      // 결과 처리 리팩토링 필수로 해야함..!
+      if (
+        (userRating !== data.rating && ratingResult && reviewResult) ||
+        (userRating === data.rating && reviewResult) ||
+        (userRating !== data.rating && reviewResult && !ratingResult)
+      ) {
+        const text =
+          userRating !== data.rating && !ratingResult
+            ? '❗️별점 등록에는 실패했습니다. 다시 시도해주세요.'
+            : '여정에 한발 더 가까워지셨어요!';
+        handleModalState({
+          isShowModal: true,
+          mainText: '작성을 완료했습니다 👍',
+          subText: text,
+          type: 'ALERT',
+          handleConfirm: () => {
+            router.push(`/review/${reviewResult.id}`);
+            handleModalState({
+              isShowModal: false,
+              mainText: '',
+            });
+          },
+        });
+      } else if (userRating !== data.rating && ratingResult && !reviewResult) {
+        router.back();
+      }
+    };
+
+    await executeApiCall(processSubmission);
   };
 
   useEffect(() => {
-    if (alcoholId) {
-      (async () => {
-        const alcoholResult = await AlcoholsApi.getAlcoholDetails(alcoholId);
-        setAlcoholData(alcoholResult.alcohols);
-
-        const ratingResult = await RateApi.getUserRating(alcoholId);
-        setInitialRating(ratingResult.rating);
-        reset((prev) => ({
-          ...prev,
-          rating: ratingResult.rating,
-        }));
-      })();
+    if (!isAlcoholLoading && userRating) {
+      reset((prev) => ({
+        ...prev,
+        rating: userRating,
+      }));
     }
-  }, [alcoholId]);
+  }, [userRating, isAlcoholLoading]);
+
+  const { showErrorModal } = useErrorModal<FormValues>(errors);
 
   useEffect(() => {
-    if (errors.review?.message || errors.price_type?.message) {
-      handleModalState({
-        isShowModal: true,
-        mainText: errors.review?.message || errors.price_type?.message,
-        type: 'ALERT',
-      });
-    }
+    showErrorModal(['review', 'price_type']);
   }, [errors]);
 
   return (
@@ -243,9 +211,14 @@ function ReviewRegister() {
         </div>
         {alcoholData && <ReviewForm korName={alcoholData.korName} />}
         <article className="px-5 fixed bottom-2 center left-0 right-0">
-          <Button onClick={handleSubmit(onSave)} btnName="리뷰 등록" />
+          <Button
+            onClick={handleSubmit(onSave)}
+            btnName="리뷰 등록"
+            disabled={isProcessing}
+          />
         </article>
       </FormProvider>
+      {(isProcessing || !alcoholData) && <Loading />}
       {state.isShowModal && <Modal />}
     </>
   );

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -13,6 +13,7 @@ import NavLayout from '@/app/(primary)/_components/NavLayout';
 import StarRating from '@/components/StarRaiting';
 import EmptyView from '@/app/(primary)/_components/EmptyView';
 import Modal from '@/components/Modal';
+import Loading from '@/components/Loading';
 import { truncStr } from '@/utils/truncStr';
 import { shareOrCopy } from '@/utils/shareOrCopy';
 import { AuthService } from '@/lib/AuthService';
@@ -92,162 +93,171 @@ function SearchAlcohol() {
 
   return (
     <>
-      <NavLayout>
-        <div className="relative">
-          {data?.alcohols?.alcoholUrlImg && (
-            <div
-              className="absolute w-full h-full  bg-cover bg-center"
-              style={{ backgroundImage: `url(${data.alcohols.alcoholUrlImg})` }}
-            />
-          )}
-          <div className="absolute w-full h-full bg-mainCoral bg-opacity-90" />
-          <SubHeader bgColor="bg-mainCoral/10">
-            <SubHeader.Left
-              onClick={() => {
-                router.back();
-              }}
-            >
-              <Image
-                src="/icon/arrow-left-white.svg"
-                alt="arrowIcon"
-                width={23}
-                height={23}
+      {alcoholDetails && data && rate ? (
+        <>
+          <NavLayout>
+            <div className="relative">
+              {data?.alcohols?.alcoholUrlImg && (
+                <div
+                  className="absolute w-full h-full  bg-cover bg-center"
+                  style={{
+                    backgroundImage: `url(${data.alcohols.alcoholUrlImg})`,
+                  }}
+                />
+              )}
+              <div className="absolute w-full h-full bg-mainCoral bg-opacity-90" />
+              <SubHeader bgColor="bg-mainCoral/10">
+                <SubHeader.Left
+                  onClick={() => {
+                    router.back();
+                  }}
+                >
+                  <Image
+                    src="/icon/arrow-left-white.svg"
+                    alt="arrowIcon"
+                    width={23}
+                    height={23}
+                  />
+                </SubHeader.Left>
+                <SubHeader.Right
+                  onClick={() => {
+                    shareOrCopy(
+                      `${process.env.NEXT_PUBLIC_BOTTLE_NOTE_URL}/category/${category}/${alcoholId}`,
+                      handleModalState,
+                      `${data?.alcohols.korName} 정보`,
+                      `${data?.alcohols.korName} 정보 상세보기`,
+                    );
+                  }}
+                >
+                  <Image
+                    src="/icon/externallink-outlined-white.svg"
+                    alt="linkIcon"
+                    width={23}
+                    height={23}
+                  />
+                </SubHeader.Right>
+              </SubHeader>
+              <AlcoholBox
+                data={data}
+                alcoholId={alcoholId}
+                isPicked={isPicked}
+                setIsPicked={setIsPicked}
               />
-            </SubHeader.Left>
-            <SubHeader.Right
-              onClick={() => {
-                shareOrCopy(
-                  `${process.env.NEXT_PUBLIC_BOTTLE_NOTE_URL}/category/${category}/${alcoholId}`,
-                  handleModalState,
-                  `${data?.alcohols.korName} 정보`,
-                  `${data?.alcohols.korName} 정보 상세보기`,
-                );
-              }}
-            >
-              <Image
-                src="/icon/externallink-outlined-white.svg"
-                alt="linkIcon"
-                width={23}
-                height={23}
-              />
-            </SubHeader.Right>
-          </SubHeader>
-          <AlcoholBox
-            data={data}
-            alcoholId={alcoholId}
-            isPicked={isPicked}
-            setIsPicked={setIsPicked}
-          />
-        </div>
-        <div className="mb-5">
-          <article className="grid place-items-center space-y-2 py-5">
-            {/* API 확인 후 수정 필요 */}
-            <p className="text-10 text-mainDarkGray">
-              이 술에 대한 평가를 남겨보세요.
-            </p>
-            <div>
-              <StarRating rate={rate} size={50} handleRate={handleRate} />
             </div>
-          </article>
-          <section className="mx-5 py-5 border-y border-mainGray/30 grid grid-cols-2 gap-2">
-            {alcoholDetails.map((item: DetailItem) => (
-              <div
-                key={item.content}
-                className="flex text-13 text-mainDarkGray items-start gap-2"
-              >
-                <div className="min-w-14 font-semibold">{item.title}</div>
-                <div className="flex-1 font-light">{item.content}</div>
-              </div>
-            ))}
-          </section>
-          {data?.alcohols?.alcoholsTastingTags && (
-            <FlavorTag tagList={data.alcohols.alcoholsTastingTags} />
-          )}
-          <section className="mx-5 py-5 border-b border-mainGray/30 space-y-2">
-            {data?.friendsInfo && (
-              <>
-                <div className="flex items-end space-x-1 text-13 text-mainDarkGray">
-                  <div>마셔본 친구</div>
-                  <div className="font-extralight">
-                    {data.friendsInfo.followerCount}
+            <div className="mb-5">
+              <article className="grid place-items-center space-y-2 py-5">
+                {/* API 확인 후 수정 필요 */}
+                <p className="text-10 text-mainDarkGray">
+                  이 술에 대한 평가를 남겨보세요.
+                </p>
+                <div>
+                  <StarRating rate={rate} size={50} handleRate={handleRate} />
+                </div>
+              </article>
+              <section className="mx-5 py-5 border-y border-mainGray/30 grid grid-cols-2 gap-2">
+                {alcoholDetails.map((item: DetailItem) => (
+                  <div
+                    key={item.content}
+                    className="flex text-13 text-mainDarkGray items-start gap-2"
+                  >
+                    <div className="min-w-14 font-semibold">{item.title}</div>
+                    <div className="flex-1 font-light">{item.content}</div>
                   </div>
-                </div>
-                <div className="whitespace-nowrap overflow-x-auto flex space-x-5 scrollbar-hide">
-                  {data.friendsInfo.friends?.map((user) => (
-                    <div
-                      key={user.userId}
-                      className="flex-shrink-0 flex flex-col items-center space-y-1"
-                    >
-                      <Link href={`/user/${user.userId}`}>
-                        <div className="w-14 h-14 rounded-full overflow-hidden">
-                          <Image
-                            className="object-cover"
-                            src={user.user_image_url}
-                            alt="user_img"
-                            width={56}
-                            height={56}
-                          />
-                        </div>
-                      </Link>
-                      <p className="text-10 text-mainDarkGray">
-                        {truncStr(user.nickName, 4)}
-                      </p>
-                      <Star rating={user.rating} size={12} />
+                ))}
+              </section>
+              {data?.alcohols?.alcoholsTastingTags && (
+                <FlavorTag tagList={data.alcohols.alcoholsTastingTags} />
+              )}
+              <section className="mx-5 py-5 border-b border-mainGray/30 space-y-2">
+                {data?.friendsInfo && (
+                  <>
+                    <div className="flex items-end space-x-1 text-13 text-mainDarkGray">
+                      <div>마셔본 친구</div>
+                      <div className="font-extralight">
+                        {data.friendsInfo.followerCount}
+                      </div>
                     </div>
+                    <div className="whitespace-nowrap overflow-x-auto flex space-x-5 scrollbar-hide">
+                      {data.friendsInfo.friends?.map((user) => (
+                        <div
+                          key={user.userId}
+                          className="flex-shrink-0 flex flex-col items-center space-y-1"
+                        >
+                          <Link href={`/user/${user.userId}`}>
+                            <div className="w-14 h-14 rounded-full overflow-hidden">
+                              <Image
+                                className="object-cover"
+                                src={user.user_image_url}
+                                alt="user_img"
+                                width={56}
+                                height={56}
+                              />
+                            </div>
+                          </Link>
+                          <p className="text-10 text-mainDarkGray">
+                            {truncStr(user.nickName, 4)}
+                          </p>
+                          <Star rating={user.rating} size={12} />
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </section>
+            </div>
+            {data?.reviewInfo?.reviewList &&
+            data.reviewInfo.totalCount !== 0 ? (
+              <>
+                <div className="h-4 bg-sectionWhite" />
+                <section className="mx-5 py-5 space-y-3">
+                  <p className="text-13 text-mainGray font-normal">
+                    총 {data.reviewInfo.totalCount}개
+                  </p>
+                  <div className="border-b border-mainGray/30" />
+                  {data.reviewInfo.reviewList.map((review) => (
+                    <React.Fragment key={review.reviewId}>
+                      <Review data={review} />
+                    </React.Fragment>
                   ))}
-                </div>
+                </section>
+                <section className="mx-5 mb-24">
+                  <LinkButton
+                    data={{
+                      engName: 'MORE COMMENTS',
+                      korName: '리뷰 더 보기',
+                      icon: true,
+                      linkSrc: {
+                        pathname: `/search/${data?.alcohols?.engCategory}/${data?.alcohols?.alcoholId}/reviews`,
+                        query: {
+                          name: data?.alcohols?.korName,
+                        },
+                      },
+                      handleBeforeRouteChange: (
+                        e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+                      ) => {
+                        if (!isLogin) {
+                          e.preventDefault();
+                          handleLoginModal();
+                        }
+                      },
+                    }}
+                  />
+                </section>
+              </>
+            ) : (
+              <>
+                <div className="h-4 bg-sectionWhite" />
+                <section className="py-5">
+                  <EmptyView text="아직 리뷰가 없어요!" />
+                </section>
               </>
             )}
-          </section>
-        </div>
-        {data?.reviewInfo?.reviewList && data.reviewInfo.totalCount !== 0 ? (
-          <>
-            <div className="h-4 bg-sectionWhite" />
-            <section className="mx-5 py-5 space-y-3">
-              <p className="text-13 text-mainGray font-normal">
-                총 {data.reviewInfo.totalCount}개
-              </p>
-              <div className="border-b border-mainGray/30" />
-              {data.reviewInfo.reviewList.map((review) => (
-                <React.Fragment key={review.reviewId}>
-                  <Review data={review} />
-                </React.Fragment>
-              ))}
-            </section>
-            <section className="mx-5 mb-24">
-              <LinkButton
-                data={{
-                  engName: 'MORE COMMENTS',
-                  korName: '리뷰 더 보기',
-                  icon: true,
-                  linkSrc: {
-                    pathname: `/search/${data?.alcohols?.engCategory}/${data?.alcohols?.alcoholId}/reviews`,
-                    query: {
-                      name: data?.alcohols?.korName,
-                    },
-                  },
-                  handleBeforeRouteChange: (
-                    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-                  ) => {
-                    if (!isLogin) {
-                      e.preventDefault();
-                      handleLoginModal();
-                    }
-                  },
-                }}
-              />
-            </section>
-          </>
-        ) : (
-          <>
-            <div className="h-4 bg-sectionWhite" />
-            <section className="py-5">
-              <EmptyView text="아직 리뷰가 없어요!" />
-            </section>
-          </>
-        )}
-      </NavLayout>
-      {state.isShowModal && <Modal />}
+          </NavLayout>
+          {state.isShowModal && <Modal />}
+        </>
+      ) : (
+        <Loading />
+      )}
     </>
   );
 }

--- a/src/app/(primary)/search/page.tsx
+++ b/src/app/(primary)/search/page.tsx
@@ -86,7 +86,7 @@ export default function Search() {
       <main className="mb-24 w-full h-full">
         <SearchContainer
           handleSearchCallback={handleSearchCallback}
-          styleProps="px-5 py-10 bg-subCoral"
+          styleProps="px-5 pt-[5.5rem] pb-10 bg-subCoral"
         />
 
         <section className="flex flex-col gap-7 p-5">

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -18,10 +18,13 @@ export function Button({
   disabled = false,
 }: ButtonProps) {
   return (
+    // disabled면 bg색을 연하게 해주고 싶어
+
     <button
       type={type}
       onClick={onClick}
-      className={`flex justify-center items-center w-full h-[3.8rem] rounded-xl ${btnStyles}`}
+      className={`flex justify-center items-center w-full h-[3.8rem] rounded-xl 
+        ${disabled ? 'bg-brightGray cursor-not-allowed' : btnStyles}`}
       disabled={disabled}
     >
       <span className={btnTextStyles}>{btnName}</span>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,7 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
 
   return (
     <nav
-      className={`fixed bottom-2 left-0 right-0 mx-auto w-full max-w-[${maxWidth}] px-4 z-10`}
+      className={`fixed bottom-3 left-0 right-0 mx-auto w-full max-w-[${maxWidth}] px-4 z-10`}
     >
       <section className="h-[4.4rem] flex justify-between bg-[#F6F6F6] py-3 px-9 rounded-[0.8rem] drop-shadow-[0_3px_3px_rgba(0,0,0,0.30)]">
         {navItems.map((menu: NavItem, index: number) => (

--- a/src/hooks/useAlcoholDetails.ts
+++ b/src/hooks/useAlcoholDetails.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { AlcoholInfo as AlcoholDetails } from '@/types/Alcohol';
+import { AlcoholsApi } from '@/app/api/AlcholsApi';
+import { RateApi } from '@/app/api/RateApi';
+
+export const useAlcoholDetails = (
+  alcoholId: string | number,
+  type = 'register',
+) => {
+  const [alcoholData, setAlcoholData] = useState<AlcoholDetails>();
+  const [userRating, setUserRating] = useState<number>(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!alcoholId) return;
+
+    const fetchData = async () => {
+      setIsLoading(true);
+      try {
+        const alcoholResult = await AlcoholsApi.getAlcoholDetails(
+          alcoholId.toString(),
+        );
+        setAlcoholData(alcoholResult.alcohols);
+
+        if (type === 'register') {
+          const ratingResult = await RateApi.getUserRating(
+            alcoholId.toString(),
+          );
+          setUserRating(ratingResult.rating);
+        }
+      } catch (err) {
+        console.error('Failed to fetch alcohol details:', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [alcoholId, type]);
+
+  return { alcoholData, userRating, isLoading };
+};

--- a/src/hooks/useCallOnce.ts
+++ b/src/hooks/useCallOnce.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export const useSingleCall = () => {
+export const useCallOnce = () => {
   const [isProcessing, setIsProcessing] = useState(false);
 
   const executeApiCall = async (apiCallFunction: () => Promise<void>) => {

--- a/src/hooks/useCallOnce.ts
+++ b/src/hooks/useCallOnce.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+export const useSingleCall = () => {
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const executeApiCall = async (apiCallFunction: () => Promise<void>) => {
+    if (isProcessing) {
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      await apiCallFunction();
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return {
+    isProcessing,
+    executeApiCall,
+  };
+};

--- a/src/hooks/useErrorModal.ts
+++ b/src/hooks/useErrorModal.ts
@@ -1,0 +1,28 @@
+import { FieldErrors } from 'react-hook-form';
+import useModalStore from '@/store/modalStore';
+
+export const useErrorModal = <T extends Record<string, any>>(
+  errors: FieldErrors<T>,
+) => {
+  const { handleModalState } = useModalStore();
+
+  const showErrorModal = (errorFields: (keyof T)[]) => {
+    const firstError = errorFields.find((field) => errors[field]?.message);
+
+    if (firstError && errors[firstError]?.message) {
+      handleModalState({
+        isShowModal: true,
+        mainText: errors[firstError]?.message as string,
+        handleConfirm: () => {
+          handleModalState({
+            isShowModal: false,
+            mainText: '',
+          });
+        },
+        type: 'ALERT',
+      });
+    }
+  };
+
+  return { showErrorModal };
+};


### PR DESCRIPTION
### PR 제목 (Title)

*  [#190] API 응답 처리 전 중복 요청 방지 로직 구현 및 review 리팩토링

### 변경 사항 (Changes)

 - [x] API 호출 후 응답 전까지 1번만 호출 가능하도록 loading 적용(QC) -> 리뷰, 문의, 신고 모두 적용
 - [x] 반복 사용하는 코드 리팩토링 -> error modal, review details get api, 스키마, 상수 등
 - [x] header, footer에 48px 적용
 - [x] 리뷰 관련 화면 loading 컴포넌트 적용

### 테스트 방법 (Test Procedure)

Alcohol, Review 관련 페이지에서 확인 가능

### 참고 사항 (Additional Information)
* header, footer px 추가 작업은 header가 배경색 연장으로 header는 각각 컴포넌트 별로 줘야 하는 상태입니다. 이번 pr에서는 footer는 layout에서 공통 적용고 제가 작업하는 페이지에는 각각 적용 완료했습니다. header는 user쪽만 확인해서 추가해주시면 될 것 같아요.
* review 페이지 관련해서 반복되는 코드 위주로 리팩토링 했습니다.
* POST, PATCH 진행 시에 중복 호출 불가능하게 hook 만들어서 적용했고 요청 후 응답이 있기 전까지는 loading 화면이 나옵니다. 제가 작업한 부분에는 모두 적용했고 혜정님 화면 중에도 필요한 부분이 있으시면 적용 부탁드려요.
* 이미지 업로드 로직도 반복 사용하는 곳이 많은데 이번에 작업한 곳이 많아서 다음 리팩토링에 진행 예정입니다.
* sespense를 이용한 loading 적용은 useEffect로 data를 가져오는 곳에서는 적용이 안되서 직접적으로 적용하는 방법으로 적용했습니다. 추후 가능한 sespense 사용 가능한 방향으로 api 호출을 바꿔보려고 합니다.