### PR TITLE
[#185] 플러터 채널링 활성화 - 로그인시 device info 받아와서 서버로 전달

### DIFF
--- a/src/app/(custom)/layout.tsx
+++ b/src/app/(custom)/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="flex flex-col w-full mx-auto min-h-screen py-12 bg-subCoral">
+    <div className="flex flex-col w-full mx-auto min-h-screen bg-subCoral">
       <main className="flex-1 overflow-y-auto">{children}</main>
     </div>
   );

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { signIn, useSession } from 'next-auth/react';
@@ -14,6 +14,7 @@ export default function Login() {
   const { data: session } = useSession();
   const router = useRouter();
   const { isLogin } = AuthService;
+  const [flutterData, setFlutterData] = useState('initial');
 
   useEffect(() => {
     if (isLogin) {
@@ -26,7 +27,7 @@ export default function Login() {
   }, []);
 
   function getDeviceToken(token: any, deviceType: any) {
-    console.log('DeviceInformation from flutter', token, deviceType);
+    setFlutterData(`${JSON.stringify(token)}, ${JSON.stringify(deviceType)}`);
   }
 
   useEffect(() => {
@@ -97,6 +98,10 @@ export default function Login() {
           </SubHeader.Left>
           <SubHeader.Center textColor="text-white">로그인</SubHeader.Center>
         </SubHeader>
+      </section>
+
+      <section>
+        <span>{flutterData}</span>
       </section>
 
       <section className="shrink-0 flex-1 flex">

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -26,9 +26,11 @@ export default function Login() {
     handleWebViewMessage('key');
   }, []);
 
-  function getDeviceToken(token: any, deviceType: any) {
-    setFlutterData(`${JSON.stringify(token)}, ${JSON.stringify(deviceType)}`);
-  }
+  useEffect(() => {
+    (window as any).getDeviceToken = (token: string, platform: string) => {
+      setFlutterData(token);
+    };
+  }, []);
 
   useEffect(() => {
     if (session) {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -29,7 +29,7 @@ export default function Login() {
 
   function getDeviceToken(token: string, platform: string) {
     try {
-      setFlutterData(token);
+      setFlutterData(JSON.stringify(token));
     } catch (e) {
       setFlutterData('error');
     }

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -49,7 +49,7 @@ export default function Login() {
     if (window.isInApp) {
       handleWebViewMessage('deviceToken');
     }
-  }, [window.isInApp]);
+  }, []);
 
   // NOTE: 인앱 상태일 때, 로그인이 완료된 상태일 때 device 정보를 서버로 전달 및 로그인 처리
   useEffect(() => {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -22,9 +22,9 @@ export default function Login() {
     }
   }, []);
 
-  useEffect(() => {
-    handleWebViewMessage('key');
-  }, []);
+  // useEffect(() => {
+  //   handleWebViewMessage('key');
+  // }, []);
 
   function getDeviceToken(token: string, platform: string) {
     try {
@@ -33,6 +33,12 @@ export default function Login() {
       setFlutterData('error');
     }
   }
+
+  useEffect(() => {
+    (window as any).getDeviceToken = getDeviceToken;
+
+    console.log('getDeviceToken registered to window');
+  }, []);
 
   useEffect(() => {
     if (session) {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -7,6 +7,7 @@ import { signIn, useSession } from 'next-auth/react';
 import { AuthService } from '@/lib/AuthService';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
 import handleWebViewMessage from '@/utils/handleWebViewMessage';
+import { UserApi } from '@/app/api/UserApi';
 import SocialLoginBtn from './_components/SocialLoginBtn';
 import LogoWhite from 'public/bottle_note_logo_white.svg';
 
@@ -27,18 +28,25 @@ export default function Login() {
     handleWebViewMessage('key');
   }, []);
 
-  function getDeviceToken(token: string, platform: string) {
+  async function getDeviceToken(token: string, platform: string) {
     try {
       setFlutterData(JSON.stringify(token));
+
+      if (isLogin) {
+        const deviceTokenSendResult = await UserApi.sendDeviceInfo(
+          token,
+          platform,
+        );
+
+        return setFlutterData(deviceTokenSendResult.data.message);
+      }
     } catch (e) {
-      setFlutterData('error');
+      setFlutterData('Failed to send token data');
     }
   }
 
   useEffect(() => {
     (window as any).getDeviceToken = getDeviceToken;
-
-    console.log('getDeviceToken registered to window');
   }, []);
 
   useEffect(() => {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -49,7 +49,7 @@ export default function Login() {
     if (window.isInApp) {
       handleWebViewMessage('deviceToken');
     }
-  }, []);
+  }, [window.isInApp]);
 
   // NOTE: 인앱 상태일 때, 로그인이 완료된 상태일 때 device 정보를 서버로 전달 및 로그인 처리
   useEffect(() => {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -23,7 +23,7 @@ export default function Login() {
   }, []);
 
   useEffect(() => {
-    // handleWebViewMessage('key');
+    handleWebViewMessage('key');
   }, []);
 
   function getDeviceToken(token: any, deviceType: any) {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { signIn, useSession } from 'next-auth/react';
 import { AuthService } from '@/lib/AuthService';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
+import handleWebViewMessage from '@/utils/handleWebViewMessage';
 import SocialLoginBtn from './_components/SocialLoginBtn';
 import LogoWhite from 'public/bottle_note_logo_white.svg';
 
@@ -19,6 +20,14 @@ export default function Login() {
       router.replace('/');
     }
   }, []);
+
+  useEffect(() => {
+    handleWebViewMessage('key');
+  }, []);
+
+  function getDeviceToken(token: any, deviceType: any) {
+    console.log('DeviceInformation from flutter', token, deviceType);
+  }
 
   useEffect(() => {
     if (session) {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -26,11 +26,13 @@ export default function Login() {
     handleWebViewMessage('key');
   }, []);
 
-  useEffect(() => {
-    (window as any).getDeviceToken = (token: string, platform: string) => {
+  function getDeviceToken(token: string, platform: string) {
+    try {
       setFlutterData(token);
-    };
-  }, []);
+    } catch (e) {
+      setFlutterData('error');
+    }
+  }
 
   useEffect(() => {
     if (session) {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -22,6 +22,7 @@ export default function Login() {
     }
   }, []);
 
+  // NOTE: Flutter 통신을 위한 핸들러. 웹 실행시 주석처리 필요 / 추후 플러터 측에서 웹뷰여부 판단하는 핸들링 채널 추가 예정
   useEffect(() => {
     handleWebViewMessage('key');
   }, []);

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -75,7 +75,7 @@ export default function Login() {
     window.checkIsInApp = checkIsInApp;
     window.sendLogToFlutter = sendLogToFlutter;
 
-    handleWebViewMessage('checkIsWebView');
+    handleWebViewMessage('checkIsInApp');
   }, []);
 
   // ----- kakao sdk login

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -22,9 +22,9 @@ export default function Login() {
     }
   }, []);
 
-  // useEffect(() => {
-  //   handleWebViewMessage('key');
-  // }, []);
+  useEffect(() => {
+    handleWebViewMessage('key');
+  }, []);
 
   function getDeviceToken(token: string, platform: string) {
     try {

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -23,7 +23,7 @@ export default function Login() {
   }, []);
 
   useEffect(() => {
-    handleWebViewMessage('key');
+    // handleWebViewMessage('key');
   }, []);
 
   function getDeviceToken(token: any, deviceType: any) {

--- a/src/app/(primary)/review/_components/KakaoAddressMap.tsx
+++ b/src/app/(primary)/review/_components/KakaoAddressMap.tsx
@@ -27,8 +27,8 @@ export default function KakaoAddressMap({ handleSaveData }: Props) {
     document.head.appendChild(script);
 
     const onLoadKakaoMap = () => {
-      window.kakao.maps.load(() => {
-        const ps = new window.kakao.maps.services.Places();
+      window.Kakao.maps.load(() => {
+        const ps = new window.Kakao.maps.services.Places();
 
         function getListItem(
           index: number,
@@ -160,12 +160,12 @@ export default function KakaoAddressMap({ handleSaveData }: Props) {
         }
 
         function placesSearchCB(data: any, status: any) {
-          if (status === window.kakao.maps.services.Status.OK) {
+          if (status === window.Kakao.maps.services.Status.OK) {
             displayPlaces(data);
             setIsOnSearch(false);
-          } else if (status === window.kakao.maps.services.Status.ZERO_RESULT) {
+          } else if (status === window.Kakao.maps.services.Status.ZERO_RESULT) {
             alert('검색 결과가 존재하지 않습니다.');
-          } else if (status === window.kakao.maps.services.Status.ERROR) {
+          } else if (status === window.Kakao.maps.services.Status.ERROR) {
             handleModalState({
               isShowModal: true,
               mainText: '검색 결과 중 오류가 발생했습니다.',

--- a/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
+++ b/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
@@ -31,7 +31,7 @@ const Header = ({
   const padding = isOpen ? 'p-7.5' : 'pb-6';
 
   return (
-    <article className={`flex justify-between ${bgColor} ${padding}`}>
+    <article className={`flex justify-between ${bgColor} ${padding} pt-[48px]`}>
       <button>
         <Image src={logoSrc} alt="보틀노트" />
       </button>

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -83,4 +83,25 @@ export const UserApi = {
 
     return result;
   },
+
+  async sendDeviceInfo(deviceToken: string, platform: string) {
+    const response = await fetchWithAuth(`/bottle-api/push/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        deviceToken,
+        platform,
+      }),
+    });
+
+    const result: ApiResponse<{
+      deviceToken: string;
+      platform: string;
+      message: string;
+    }> = await response.json();
+
+    return result;
+  },
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -7,7 +7,11 @@ declare global {
     getDeviceToken: (
       token: string,
       platform: string,
-    ) => { token: string; platform: string };
+    ) => { deviceToken: string; platform: string };
+    checkIsInApp: (status: string) => boolean;
+    sendLogToFlutter: (log: string) => void;
+    isInApp: boolean = false;
+    deviceInfo: { deviceToken: string; platform: string };
   }
 }
 

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,6 +1,9 @@
 declare global {
   interface Window {
     Kakao: any;
+    FlutterMessageQueue: {
+      postMessage: (payload: any) => any;
+    };
   }
 }
 

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -4,6 +4,10 @@ declare global {
     FlutterMessageQueue: {
       postMessage: (payload: any) => any;
     };
+    getDeviceToken: (
+      token: string,
+      platform: string,
+    ) => { token: string; platform: string };
   }
 }
 

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -1,0 +1,29 @@
+export function checkIsInApp(status: string) {
+  const result = status === 'false' ? false : Boolean(status);
+  window.isInApp = result;
+  return result;
+}
+
+export function getDeviceToken(token: string, platform: string) {
+  window.deviceInfo = { deviceToken: token, platform };
+  return { deviceToken: token, platform };
+}
+
+export function sendLogToFlutter(log: string) {
+  if (window.isInApp) {
+    // 웹뷰일 때 로그 출력
+    console.log(`[Message sent to Flutter - WebView] ${log}`);
+  } else {
+    // 웹뷰가 아닐 때 로그 출력
+    console.log(`[Message sent to Flutter - Browser] ${log}`);
+  }
+  return log;
+}
+
+export function handleWebViewMessage(message: string) {
+  return window.FlutterMessageQueue.postMessage(message);
+}
+
+window.getDeviceToken = getDeviceToken;
+window.checkIsInApp = checkIsInApp;
+window.sendLogToFlutter = sendLogToFlutter;

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -20,6 +20,6 @@ export function sendLogToFlutter(log: string) {
   return log;
 }
 
-export function handleWebViewMessage(message: string) {
+export function handleWebViewMessage(message: 'checkIsInApp' | 'deviceToken') {
   return window.FlutterMessageQueue.postMessage(message);
 }

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -23,7 +23,3 @@ export function sendLogToFlutter(log: string) {
 export function handleWebViewMessage(message: string) {
   return window.FlutterMessageQueue.postMessage(message);
 }
-
-window.getDeviceToken = getDeviceToken;
-window.checkIsInApp = checkIsInApp;
-window.sendLogToFlutter = sendLogToFlutter;

--- a/src/utils/handleWebViewMessage.ts
+++ b/src/utils/handleWebViewMessage.ts
@@ -1,0 +1,5 @@
+function handleWebViewMessage(payload: any) {
+  return window.FlutterMessageQueue.postMessage(payload);
+}
+
+export default handleWebViewMessage;

--- a/src/utils/handleWebViewMessage.ts
+++ b/src/utils/handleWebViewMessage.ts
@@ -1,5 +1,0 @@
-function handleWebViewMessage(payload: any) {
-  return window.FlutterMessageQueue.postMessage(payload);
-}
-
-export default handleWebViewMessage;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,0 @@
-declare global {
-  interface Window {
-    kakao: any;
-  }
-}
-
-export {};


### PR DESCRIPTION
### PR 제목 (Title)

[#185] 플러터 채널링 활성화 - 로그인시 device info 받아와서 서버로 전달

### 변경 사항 (Changes)

* 체크리스트
  - 로그인이 되었을 때 flutter 특정 채널로 device 정보 전달
  - 플러터에서 device token 정보 받아와서 로그인 화면에 띄워주도록 일단 추가 (확인용으로 추후 제거 예정)
  - 인앱 웹뷰 상태인지 확인해서 웹브라우저모드, 웹뷰모드 분기처리하는 플러터 채널 추가 필요

### 변경 이유 (Reason for Changes)

* 디바이스 정보를 유저별로 저장하기 위해서 데이터를 보내주어야 함

### 테스트 방법 (Test Procedure)

* 웹에서는 테스트가 안되고 모바일에서만 가능합니다 일단.
* 웹뷰 여부 판단하는 채널 추가하여 빌드 된 이후 다시 노티 드릴게요
