### PR TITLE
[HotFix]변경 안된 hook 이름 변경

### DIFF
--- a/src/app/(primary)/report/page.tsx
+++ b/src/app/(primary)/report/page.tsx
@@ -10,7 +10,7 @@ import { ReportApi } from '@/app/api/ReportApi';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
 import { Button } from '@/components/Button';
 import { FormValues, ReportTypeMap } from '@/types/Report';
-import { useCallOnce } from '@/hooks/useCallOnce';
+import { useSingleApiCall } from '@/hooks/useSingleApiCall';
 import { useErrorModal } from '@/hooks/useErrorModal';
 import useModalStore from '@/store/modalStore';
 import Modal from '@/components/Modal';
@@ -50,7 +50,7 @@ export default function Report() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { state, handleModalState } = useModalStore();
-  const { isProcessing, executeApiCall } = useCallOnce();
+  const { isProcessing, executeApiCall } = useSingleApiCall();
 
   const type = searchParams.get('type') as ReportType;
   const reportUserId = searchParams.get('userId');


### PR DESCRIPTION
### PR 제목 (Title)

[HotFix]변경 안된 hook 이름 변경

### 변경 사항 (Changes)
  - [x] report안에 변경 안된 useCallOnce를 useSingleApiCall로 변경

### 변경 이유 (Reason for Changes)

이전 변경 시 빠진 부분이 있어 현대 빌드 버그 발생.
