### PR TITLE
[#241] 로그인 컨텍스트 QC 사항 수정

### DIFF
--- a/src/app/api/AuthApi.ts
+++ b/src/app/api/AuthApi.ts
@@ -61,6 +61,7 @@ export const AuthApi = {
       );
     }
   },
+
   async kakaoLogin(code: string | string[]): Promise<LoginReturn> {
     try {
       const res = await fetch(`/api/oauth/kakao?code=${code}`, {
@@ -101,6 +102,31 @@ export const AuthApi = {
 
       throw new Error(
         `게스트 로그인 도중 에러가 발생했습니다. 사유: ${error.message}`,
+      );
+    }
+  },
+
+  async verifyToken(accessToken: string) {
+    try {
+      const res = await fetch(`/bottle-api/oauth/token/verify`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          token: accessToken,
+        }),
+      });
+
+      const { data } = await res.json();
+
+      return { data };
+    } catch (e) {
+      const error = e as Error;
+      console.error(error.message);
+
+      throw new Error(
+        `토큰 검증 도중 에러가 발생했습니다. 사유: ${error.message}`,
       );
     }
   },

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -30,18 +30,6 @@ export const UserApi = {
     return data;
   },
 
-  async getUserInfoWithAuth({
-    userId,
-  }: {
-    userId: string;
-  }): Promise<UserInfoApi> {
-    const response = await fetchWithAuth(`/bottle-api/my-page/${userId}`);
-
-    const { data }: ApiResponse<UserInfoApi> = response;
-
-    return data;
-  },
-
   async changeProfileImage(profileImageSrc: string | null) {
     const response = await fetchWithAuth(`/bottle-api/users/profile-image`, {
       method: 'PATCH',

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -30,6 +30,18 @@ export const UserApi = {
     return data;
   },
 
+  async getUserInfoWithAuth({
+    userId,
+  }: {
+    userId: string;
+  }): Promise<UserInfoApi> {
+    const response = await fetchWithAuth(`/bottle-api/my-page/${userId}`);
+
+    const { data }: ApiResponse<UserInfoApi> = response;
+
+    return data;
+  },
+
   async changeProfileImage(profileImageSrc: string | null) {
     const response = await fetchWithAuth(`/bottle-api/users/profile-image`, {
       method: 'PATCH',

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,7 +14,7 @@ export interface NavItem {
 
 function Navbar({ maxWidth }: { maxWidth: string }) {
   const pathname = usePathname();
-  const { userData } = AuthService;
+  const { isLogin, userData } = AuthService;
 
   const navItems: NavItem[] = [
     { name: '홈', link: '/', icon: '/icon/home-outlined-subcoral.svg' },
@@ -26,12 +26,12 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
     },
     {
       name: '기록',
-      link: userData ? '/history' : '/login',
+      link: isLogin ? '/history' : '/login',
       icon: '/icon/document-outlined-subcoral.svg',
     },
     {
       name: '마이',
-      link: userData ? `/user/${userData.userId}` : '/login',
+      link: isLogin && userData ? `/user/${userData.userId}` : '/login',
       icon: '/icon/user-outlined-subcoral.svg',
     },
   ];
@@ -66,7 +66,6 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
             )}
           </React.Fragment>
         ))}
-        {/* 로그인 user가 아니면? 없어지는가? */}
       </section>
     </nav>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,8 +3,9 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { AuthService } from '@/lib/AuthService';
+import { checkTokenValidity } from '@/utils/checkTokenValidity';
 
 export interface NavItem {
   name: string;
@@ -13,8 +14,9 @@ export interface NavItem {
 }
 
 function Navbar({ maxWidth }: { maxWidth: string }) {
+  const router = useRouter();
   const pathname = usePathname();
-  const { isLogin, userData } = AuthService;
+  const { isLogin, userData, logout } = AuthService;
 
   const navItems: NavItem[] = [
     { name: '홈', link: '/', icon: '/icon/home-outlined-subcoral.svg' },
@@ -36,6 +38,35 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
     },
   ];
 
+  const handleCheckIsLogin = async () => {
+    if (!userData) {
+      logout();
+      return router.push('/login');
+    }
+
+    if (userData) {
+      const verifyResult = await checkTokenValidity();
+      if (!verifyResult) {
+        logout();
+        return router.push('/login');
+      }
+    }
+
+    return router.push(`/user/${userData.userId}`);
+  };
+
+  const isActive = (link: string, pathName: string) => {
+    if (
+      link === '/' ||
+      link === '/search' ||
+      link === '/rating' ||
+      link === '/history'
+    ) {
+      return link === pathName;
+    }
+    return pathName.startsWith(link);
+  };
+
   return (
     <nav
       className={`fixed bottom-6 left-0 right-0 mx-auto w-full max-w-[${maxWidth}] px-4 z-10`}
@@ -43,24 +74,19 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
       <section className="h-[4.4rem] flex justify-between bg-[#F6F6F6] py-3 px-5 rounded-[0.8rem] drop-shadow-[0_3px_3px_rgba(0,0,0,0.30)]">
         {navItems.map((menu: NavItem, index: number) => (
           <React.Fragment key={menu.link}>
-            <Link
-              className={`flex flex-col items-center space-y-1 ${
-                (menu.link === '/' && pathname === '/') ||
-                (menu.link === '/search' && pathname === '/search') ||
-                (menu.link === '/rating' && pathname === '/rating') ||
-                (menu.link === '/history' && pathname === '/history') ||
-                (menu.link.startsWith('/user/') &&
-                  pathname.startsWith('/user/'))
-                  ? ''
-                  : 'opacity-40'
-              }`}
-              href={menu.link}
+            <button
+              className={`flex flex-col items-center space-y-1 ${isActive(menu.link, pathname) ? '' : 'opacity-40'}`}
+              onClick={
+                menu.name === '마이'
+                  ? handleCheckIsLogin
+                  : () => router.push(menu.link)
+              }
             >
               <div className="flex flex-col items-center justify-center space-y-[2px]">
                 <Image src={menu.icon} alt={menu.name} width={30} height={30} />
                 <span className="text-9 text-subCoral">{menu.name}</span>
               </div>
-            </Link>
+            </button>
             {index !== navItems.length - 1 && (
               <span className="border-[0.01rem] border-subCoral opacity-40" />
             )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { AuthService } from '@/lib/AuthService';
 import { checkTokenValidity } from '@/utils/checkTokenValidity';
@@ -11,76 +10,55 @@ export interface NavItem {
   name: string;
   link: string;
   icon: string;
+  requiresAuth?: boolean;
 }
 
 function Navbar({ maxWidth }: { maxWidth: string }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { isLogin, userData, logout } = AuthService;
+  const { userData, logout } = AuthService;
 
   const navItems: NavItem[] = [
     { name: '홈', link: '/', icon: '/icon/home-outlined-subcoral.svg' },
     { name: '검색', link: '/search', icon: '/icon/search-subcoral.svg' },
-    {
-      name: '별점',
-      link: '/rating',
-      icon: '/icon/star-filled-subcoral.svg',
-    },
+    { name: '별점', link: '/rating', icon: '/icon/star-filled-subcoral.svg' },
     {
       name: '기록',
-      link: isLogin ? '/history' : '/login',
+      link: '/history',
       icon: '/icon/document-outlined-subcoral.svg',
+      requiresAuth: true,
     },
     {
       name: '마이',
-      link: isLogin && userData ? `/user/${userData.userId}` : '/login',
+      link: `/user/${userData?.userId || ''}`,
       icon: '/icon/user-outlined-subcoral.svg',
+      requiresAuth: true,
     },
   ];
 
-  const handleCheckIsLogin = async () => {
-    if (!userData) {
-      logout();
-      return router.push('/login');
-    }
-
-    if (userData) {
-      const verifyResult = await checkTokenValidity();
-      if (!verifyResult) {
+  const handleNavigation = async (menu: NavItem) => {
+    if (menu.requiresAuth) {
+      if (!userData || !(await checkTokenValidity())) {
         logout();
         return router.push('/login');
       }
     }
-
-    return router.push(`/user/${userData.userId}`);
+    router.push(menu.link);
   };
 
-  const isActive = (link: string, pathName: string) => {
-    if (
-      link === '/' ||
-      link === '/search' ||
-      link === '/rating' ||
-      link === '/history'
-    ) {
-      return link === pathName;
-    }
-    return pathName.startsWith(link);
-  };
+  const isActive = (link: string) =>
+    pathname === link || pathname.startsWith(link);
 
   return (
     <nav
       className={`fixed bottom-6 left-0 right-0 mx-auto w-full max-w-[${maxWidth}] px-4 z-10`}
     >
       <section className="h-[4.4rem] flex justify-between bg-[#F6F6F6] py-3 px-5 rounded-[0.8rem] drop-shadow-[0_3px_3px_rgba(0,0,0,0.30)]">
-        {navItems.map((menu: NavItem, index: number) => (
+        {navItems.map((menu, index) => (
           <React.Fragment key={menu.link}>
             <button
-              className={`flex flex-col items-center space-y-1 ${isActive(menu.link, pathname) ? '' : 'opacity-40'}`}
-              onClick={
-                menu.name === '마이'
-                  ? handleCheckIsLogin
-                  : () => router.push(menu.link)
-              }
+              className={`flex flex-col items-center space-y-1 ${isActive(menu.link) ? '' : 'opacity-40'}`}
+              onClick={() => handleNavigation(menu)}
             >
               <div className="flex flex-col items-center justify-center space-y-[2px]">
                 <Image src={menu.icon} alt={menu.name} width={30} height={30} />

--- a/src/utils/checkTokenValidity.ts
+++ b/src/utils/checkTokenValidity.ts
@@ -1,15 +1,15 @@
-import { UserApi } from '@/app/api/UserApi';
+import { AuthApi } from '@/app/api/AuthApi';
 import { AuthService } from '@/lib/AuthService';
 
-// TODO: Token verification api 적용
 export const checkTokenValidity = async (): Promise<boolean> => {
-  const { userData } = AuthService;
+  const { userData, getToken } = AuthService;
+  const token = getToken()?.accessToken;
 
-  if (!userData) return false;
+  if (!userData || !token) return false;
 
-  const userInfoResponse = await UserApi.getUserInfoWithAuth({
-    userId: `${userData.userId}`,
-  });
+  const { data: result } = await AuthApi.verifyToken(token);
 
-  return userInfoResponse.isMyPage;
+  if (result.includes('invalid')) return false;
+
+  return true;
 };

--- a/src/utils/checkTokenValidity.ts
+++ b/src/utils/checkTokenValidity.ts
@@ -1,0 +1,15 @@
+import { UserApi } from '@/app/api/UserApi';
+import { AuthService } from '@/lib/AuthService';
+
+// TODO: Token verification api 적용
+export const checkTokenValidity = async (): Promise<boolean> => {
+  const { userData } = AuthService;
+
+  if (!userData) return false;
+
+  const userInfoResponse = await UserApi.getUserInfoWithAuth({
+    userId: `${userData.userId}`,
+  });
+
+  return userInfoResponse.isMyPage;
+};

--- a/src/utils/checkTokenValidity.ts
+++ b/src/utils/checkTokenValidity.ts
@@ -2,14 +2,12 @@ import { AuthApi } from '@/app/api/AuthApi';
 import { AuthService } from '@/lib/AuthService';
 
 export const checkTokenValidity = async (): Promise<boolean> => {
-  const { userData, getToken } = AuthService;
-  const token = getToken()?.accessToken;
+  const token = AuthService.getToken()?.accessToken;
 
-  if (!userData || !token) return false;
+  // 토큰이 없거나 userData 존해하지 않음
+  if (!token || !AuthService.userData) return false;
 
+  // 토큰 검증하여 invalid 라는 문구가 없으면 유효 토큰
   const { data: result } = await AuthApi.verifyToken(token);
-
-  if (result.includes('invalid')) return false;
-
-  return true;
+  return !result.includes('invalid');
 };

--- a/src/utils/fetchWithAuth.ts
+++ b/src/utils/fetchWithAuth.ts
@@ -19,8 +19,10 @@ export const fetchWithAuth: FetchWithAuth = async (
   retryCount = 0,
 ) => {
   const { requireAuth = true, ...fetchOptions } = options;
+
   const token = AuthService.getToken();
 
+  // 인증이 필요하지만 토큰이 없는 경우 → 로그아웃 처리 후 로그인 모달 열기
   if (requireAuth && !token) {
     AuthService.logout();
     const { handleLoginState } = useModalStore.getState();
@@ -29,18 +31,24 @@ export const fetchWithAuth: FetchWithAuth = async (
   }
 
   const requestUrl = `${url}`;
+
   let res: any = new Error('API 호출 중 에러가 발생했습니다.');
 
+  // 인증이 필요 없지만 토큰이 없는 경우
   if (!token) {
     try {
+      // 인증 없이 API 요청
       const response = await fetch(requestUrl, { ...fetchOptions });
 
+      // 응답이 실패한 경우 → 에러 응답을 저장
       if (!response.ok) {
         res = await response.json();
       }
 
+      // 정상 응답 반환
       return await response.json();
     } catch (error) {
+      // ApiError인 경우 콘솔에 상세 정보 출력
       if (error instanceof ApiError) {
         console.log('API Error Response of fetch:', error.response);
       }
@@ -48,6 +56,7 @@ export const fetchWithAuth: FetchWithAuth = async (
     }
   }
 
+  // 인증이 필요한 요청의 기본 옵션 구성
   const defaultOptions = {
     ...fetchOptions,
     headers: {
@@ -58,24 +67,30 @@ export const fetchWithAuth: FetchWithAuth = async (
   };
 
   try {
+    // API 요청 수행 (인증 포함)
     const response = await fetch(requestUrl, defaultOptions);
 
+    // 응답이 실패한 경우 → 에러 응답 저장
     if (!response.ok) {
       res = await response.json();
 
-      // case 1: 에러 코드가 403인 경우 -> 기간 만료이므로 리프레시 토큰으로 갱신
+      // 토큰이 만료된 경우 (403) → 리프레시 토큰으로 재시도
       if (res.code === 403 && retryCount < 1) {
         try {
+          // 새로운 토큰 요청
           const newTokens = await AuthApi.renewTokenClientSide(
             token.refreshToken,
           );
 
+          // 새로운 토큰 저장
           AuthService.setToken(newTokens);
 
+          // 새로운 토큰이 없으면 에러 처리
           if (!newTokens) {
             throw new Error('갱신된 액세스 토큰이 존재하지 않습니다.');
           }
 
+          // 재귀적으로 fetchWithAuth를 다시 호출하여 요청 재시도
           return await fetchWithAuth(url, fetchOptions, retryCount + 1);
         } catch (e) {
           throw new ApiError(`HTTP error! ${e}`, response);
@@ -83,8 +98,10 @@ export const fetchWithAuth: FetchWithAuth = async (
       }
     }
 
+    // 정상 응답 반환
     return await response.json();
   } catch (error) {
+    // ApiError 발생 시 콘솔에 상세 정보 출력
     if (error instanceof ApiError) {
       console.log('API Error Response:', error.response);
     }


### PR DESCRIPTION
### PR 제목 (Title)

* #241 

### 변경 사항 (Changes)

- [x] Navbar 에서 인증이 필요한 페이지 (history, my page) 진입시 토큰 유효성 여부를 검사하도록 수정
- [x] 그에 따른 Navbar 로직 리팩토링
- [x] 리팩토링 필요해보이는 fetchWithAuth 함수에 일단 설명 주석만 달아둠

### 변경 이유 (Reason for Changes)

- 문제 상황
  - 로그아웃 상태인데도 마이페이지 접속했다가, 뭘 하나 클릭해야 그제서야 로그인 알림 모달이 뜸
  
- 문제 원인
  - 토큰이 만료되어 로그아웃 처리가 되야함에도, api 쏘기 전까지는 만료 여부를 모름
  - 모든 api 가 토큰을 필요로 하지도, 토큰에 대한 유효성을 검사하지도 않음
  - 기존 로직에서 확인하던 userData 는 로그인 이후 쭉 저장되는 것이라서 만료 여부 추적 X
  
 - 해결  
   -  마이 페이지 접근 전 토큰 검증 api 쏴서 만료 여부 체크


### 테스트 방법 (Test Procedure)

- 토큰 만료 이후 마이페이지/히스토리 페이지 Navbar 통해서 방문

### 참고 사항 (Additional Information)

* url 접근은 안막고 있는데, 어차피 웹에 공개될 일이 없기 때문에 넘어가도 될듯?
