### PR TITLE
[Hotfix] User 페이지에 히스토리 컴포넌트와 sidebarHeader 겹침 수정

### DIFF
--- a/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
+++ b/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
@@ -146,7 +146,7 @@ const SidebarHeader = () => {
 
       {isOpen && (
         <motion.aside
-          className="z-10 bg-[#F0996E] bg-opacity-85 fixed inset-0 backdrop-blur-sm"
+          className="z-20 bg-[#F0996E] bg-opacity-85 fixed inset-0 backdrop-blur-sm"
           initial="closed"
           animate="open"
           exit="closed"

--- a/src/app/(primary)/user/[id]/_components/Timeline.tsx
+++ b/src/app/(primary)/user/[id]/_components/Timeline.tsx
@@ -1,13 +1,58 @@
 import React, { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import EmptyView from '@/app/(primary)/_components/EmptyView';
 import TimeLineItem from '@/app/(primary)/_components/TimeLineItem';
 import Label from '@/app/(primary)/_components/Label';
+import LinkButton from '@/components/LinkButton';
+import useModalStore from '@/store/modalStore';
+import { AuthService } from '@/lib/AuthService';
 import { HistoryApi } from '@/types/History';
 import { formatDate } from '@/utils/formatDate';
 
 import { HISTORY_MOCK_LIST_ITEM } from '../../../../../../mock/history';
 
 function Timeline() {
+  const router = useRouter();
+  const { handleModalState, handleLoginModal } = useModalStore();
+  const { userData: loginUserData, isLogin } = AuthService;
+
+  const handleConfirmUser = () => {
+    if (!isLogin) {
+      handleLoginModal();
+      return;
+    }
+
+    // ! 아래 코드 주석처리 후 주석된 코드 주석 제거하면 확인 가능
+    handleModalState({
+      isShowModal: true,
+      type: 'ALERT',
+      mainText: '현재 기능 준비중입니다:)',
+      handleConfirm: () => {
+        handleModalState({
+          isShowModal: false,
+          mainText: '',
+        });
+      },
+    });
+
+    // if (loginUserData?.userId !== Number(id)) {
+    //   handleModalState({
+    //     isShowModal: true,
+    //     type: 'ALERT',
+    //     mainText: '여기까지 볼 수 있어요!',
+    //     subText: '더 자세한 히스토리는 다른사람에게\n공유되지않아요~😘',
+    //     handleConfirm: () => {
+    //       handleModalState({
+    //         isShowModal: false,
+    //         mainText: '',
+    //       });
+    //     },
+    //   });
+    // } else {
+    //   router.push('/history');
+    // }
+  };
+
   const groupHistoryByDate = (historyItems: HistoryApi[]) => {
     const sortedItems = [...historyItems].sort(
       (a, b) =>
@@ -31,11 +76,11 @@ function Timeline() {
     return groupedItems;
   };
 
-  const groupedHistory = groupHistoryByDate(HISTORY_MOCK_LIST_ITEM);
-
+  const TEST_DATA: any[] = []; // HISTORY_MOCK_LIST_ITEM로 바꾸면 화면 확인 가능
+  const groupedHistory = groupHistoryByDate(TEST_DATA);
   const gradientHeight = useMemo(() => {
-    return HISTORY_MOCK_LIST_ITEM.length <= 3 ? '150px' : '400px';
-  }, [HISTORY_MOCK_LIST_ITEM]);
+    return TEST_DATA.length <= 3 ? '150px' : '400px';
+  }, [TEST_DATA]);
 
   if (Object.keys(groupedHistory).length === 0) {
     return (
@@ -48,8 +93,8 @@ function Timeline() {
   }
 
   return (
-    <section>
-      <article>
+    <article>
+      <div>
         <div className="font-semibold">
           <p className="text-15 text-subCoral">나의 보틀 여정 히스토리</p>
           <p className="text-10 text-brightGray">
@@ -108,8 +153,22 @@ function Timeline() {
           />
         </div>
         <div className="mb-2" />
-      </article>
-    </section>
+      </div>
+      <LinkButton
+        data={{
+          engName: 'HISTORY',
+          korName: '활동 히스토리',
+          linkSrc: `/history`,
+          icon: true,
+          handleBeforeRouteChange: (
+            e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+          ) => {
+            e.preventDefault();
+            handleConfirmUser();
+          },
+        }}
+      />
+    </article>
   );
 }
 

--- a/src/app/(primary)/user/[id]/page.tsx
+++ b/src/app/(primary)/user/[id]/page.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import LinkButton from '@/components/LinkButton';
 import { UserInfoApi } from '@/types/User';
 import { UserApi } from '@/app/api/UserApi';
-import useModalStore from '@/store/modalStore';
-import { AuthService } from '@/lib/AuthService';
 import UserInfo from './_components/UserInfo';
 import HistoryOverview from './_components/HistoryOverview';
 import SidebarHeader from './_components/SidebarHeader';
@@ -15,46 +11,6 @@ import NavLayout from '../../_components/NavLayout';
 
 export default function User({ params: { id } }: { params: { id: string } }) {
   const [userData, setUserData] = useState<UserInfoApi | null>(null);
-  const router = useRouter();
-  const { handleModalState, handleLoginModal } = useModalStore();
-  const { userData: loginUserData, isLogin } = AuthService;
-
-  const handleConfirmUser = () => {
-    if (!isLogin) {
-      handleLoginModal();
-      return;
-    }
-
-    // ! 아래 코드 주석처리 후 주석된 코드 주석 제거하면 확인 가능
-    handleModalState({
-      isShowModal: true,
-      type: 'ALERT',
-      mainText: '현재 기능 준비중입니다:)',
-      handleConfirm: () => {
-        handleModalState({
-          isShowModal: false,
-          mainText: '',
-        });
-      },
-    });
-
-    // if (loginUserData?.userId !== Number(id)) {
-    //   handleModalState({
-    //     isShowModal: true,
-    //     type: 'ALERT',
-    //     mainText: '여기까지 볼 수 있어요!',
-    //     subText: '더 자세한 히스토리는 다른사람에게\n공유되지않아요~😘',
-    //     handleConfirm: () => {
-    //       handleModalState({
-    //         isShowModal: false,
-    //         mainText: '',
-    //       });
-    //     },
-    //   });
-    // } else {
-    //   router.push('/history');
-    // }
-  };
 
   useEffect(() => {
     (async () => {
@@ -83,23 +39,8 @@ export default function User({ params: { id } }: { params: { id: string } }) {
             id={Number(id)}
           />
         </section>
-
-        <section className="px-5 pt-9 flex flex-col gap-5">
+        <section className="px-5 pt-9">
           <Timeline />
-          <LinkButton
-            data={{
-              engName: 'HISTORY',
-              korName: '활동 히스토리',
-              linkSrc: `/history`,
-              icon: true,
-              handleBeforeRouteChange: (
-                e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-              ) => {
-                e.preventDefault();
-                handleConfirmUser();
-              },
-            }}
-          />
         </section>
       </main>
     </NavLayout>


### PR DESCRIPTION
### PR 제목 (Title)

* [Hotfix]User 페이지에 히스토리 컴포넌트와 sidebarHeader 겹침 수정

### 변경 사항 (Changes)

- [x] sidebarHeader z-index 수정
- [x] 유저 페이지에 히스토리 링크 버튼 위치 Timeline 컴포넌트로 위치 변경
- [x] 더미데이트 주석 처리

### 변경 이유 (Reason for Changes)

- 문제 상황
  - sidebarHeader에 히스토리 및 네브바가 더 위로 나오는 문제
  - 히스토리 더미데이터가 유저 히스토리에 그대로 나오는 문제
  
- 문제 원인
  - 히스토리 컴포넌트, 네브바 그리고 sidebarHeader의 떠있는 값이 동일한 문제
  - 더이데이터를 그대로 사용하고 있는 문제
  
 - 해결  
   -  z-index값 변경
   - 더미데이터 주석 처리 후 []값 사용


### 테스트 방법 (Test Procedure)

- 유저페이지에서 확인 가능

### 참고 사항 (Additional Information)

* 유저 페이지에 히스토리 링크는 히스토리가 없을 때 안나오게 하려고 timeline 컴포넌트 안으로 옮겼습니다.
