### PR TITLE
[Hotfix] 별점, 검색 list item 레이아웃 깨짐 및 navbar active 조건 수정

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -31,50 +31,54 @@ const ListItem = ({ data }: Props) => {
   const [isPicked, setIsPicked] = useState(initialIsPicked);
 
   return (
-    <section className="grid grid-cols-2 text-mainBlack border-brightGray border-b h-[90px]">
-      <Link href={`/search/all/${alcoholId}`} className="grid grid-cols-2">
-        <ItemImage src={imageUrl} alt="위스키 이미지" />
-        <article className="flex w-full justify-between items-center">
+    <section className="grid grid-cols-5 text-mainBlack border-brightGray border-b h-[90px]">
+      <div className="col-span-4">
+        <Link
+          href={`/search/all/${alcoholId}`}
+          className="flex justify-start items-center h-full"
+        >
+          <ItemImage src={imageUrl} alt="위스키 이미지" />
           <ItemInfo
             korName={addNewLine(korName)}
             engName={engName}
             korCategory={korCategoryName}
           />
-        </article>
-      </Link>
+        </Link>
+      </div>
 
       <article className="flex flex-col justify-center">
-        <div className="">
+        <div className="flex flex-col items-end">
           <Star rating={rating} />
-        </div>
-
-        <div
-          className={`flex justify-end text-xxs text-right tracking-wider ${!ratingCount && 'hidden'}`}
-        >
-          (
-          <Image src={RatingCountIcon} alt="별점 평가 참여자 수" />
-          <span className="">{`${ratingCount ?? 0}`}</span>)
-        </div>
-
-        <div className="flex justify-end mt-1.5 gap-1">
-          <Link
-            href={
-              isMyPage
-                ? `/search/all/${alcoholId}/reviews?name=${korName}`
-                : `/search/all/${alcoholId}/reviews?name=${korName}`
-            }
+          <div
+            className={`flex justify-end text-xxs text-right tracking-wider ${!ratingCount && 'hidden'}`}
           >
-            {hasReviewByMe === true && <Image src={HasReviewIcon} alt="리뷰" />}
-            {hasReviewByMe === false && <Image src={ReviewIcon} alt="리뷰" />}
-          </Link>
-          <PickBtn
-            isPicked={isPicked}
-            alcoholId={alcoholId}
-            iconColor="subcoral"
-            handleUpdatePicked={() => setIsPicked(!isPicked)}
-            handleError={() => console.error('찜하기 도중 에러 발생')}
-            handleNotLogin={() => {}}
-          />
+            (
+            <Image src={RatingCountIcon} alt="별점 평가 참여자 수" />
+            <span>{`${ratingCount ?? 0}`}</span>)
+          </div>
+
+          <div className="flex justify-end mt-1.5 gap-1">
+            <Link
+              href={
+                isMyPage
+                  ? `/search/all/${alcoholId}/reviews?name=${korName}`
+                  : `/search/all/${alcoholId}/reviews?name=${korName}`
+              }
+            >
+              {hasReviewByMe === true && (
+                <Image src={HasReviewIcon} alt="리뷰" />
+              )}
+              {hasReviewByMe === false && <Image src={ReviewIcon} alt="리뷰" />}
+            </Link>
+            <PickBtn
+              isPicked={isPicked}
+              alcoholId={alcoholId}
+              iconColor="subcoral"
+              handleUpdatePicked={() => setIsPicked(!isPicked)}
+              handleError={() => console.error('찜하기 도중 에러 발생')}
+              handleNotLogin={() => {}}
+            />
+          </div>
         </div>
       </article>
     </section>

--- a/src/components/List/_components/ItemInfo.tsx
+++ b/src/components/List/_components/ItemInfo.tsx
@@ -9,9 +9,7 @@ interface Props {
 
 const ItemInfo = ({ korName, engName, korCategory, engCategory }: Props) => (
   <article className="flex flex-col space-y-2">
-    <h2 className="whitespace-pre text-sm leading-sm font-bold line">
-      {korName}
-    </h2>
+    <h2 className="text-sm leading-sm font-bold line">{korName}</h2>
     <p className="text-xxs">
       <span>{truncStr(engName.toUpperCase(), 20)}</span>
       <span> · {korCategory}</span>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -46,8 +46,12 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
     router.push(menu.link);
   };
 
-  const isActive = (link: string) =>
-    pathname === link || pathname.startsWith(link);
+  const isActive = (link: string) => {
+    if (link === '/') {
+      return pathname === '/';
+    }
+    return pathname === link || pathname.startsWith(link);
+  };
 
   return (
     <nav


### PR DESCRIPTION
### PR 제목 (Title)

* [Hotfix] 별점, 검색 list item 레이아웃 깨짐 및 navbar active 조건 수정

### 변경 사항 (Changes)

- [x] List 컴포넌트에 item 레이아웃 수정(사파리 버그)
- [x] navbar의 isActive 조건 수정

### 변경 이유 (Reason for Changes)

- 문제 상황
  - List : 사파리에서 별점 레이아웃이 깨지는 문제
  - navbar : 어떤 페이지를 가든 홈도 항상 선택되어 있는 클래스 적용되는 문제
  
 - 해결  
   - List : 정확한 원인은 못 찾았어요... 사파리에서 스타일 적용 순서에 따라 달라지는 경우도 있을 수 있다고 하고 일단은
               스타일을 전반적으로 사파리에서 문제없이 나오는 것이 확인된 스타일로 변경 
   - navbar : home을 먼저 확인해서 적용되도록 조건 수정

### 테스트 방법 (Test Procedure)

- 검색, 별점 페이지에서 확인 가능

### 참고 사항 (Additional Information)

* ItemInfo에서 한글이름이 나오는 부분에 'whitespace-pre'가 적용되어 있었는데 없는게 레이아웃이 더 자연스러워서 제거했습니다. 혹시 꼭 있어야하는 클래스인지 확인 부탁드려요!
* 혹시라고 사파리에서 추가적인 스타일 문제가 있다면 공부 좀 해서 재발 방지 방안을 찾아야할 것 같아요.
