### PR TITLE
[#256] 리뷰 카메라, 앨범 연동 추가 (플러터)

### DIFF
--- a/src/app/(primary)/inquire/register/page.tsx
+++ b/src/app/(primary)/inquire/register/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import * as yup from 'yup';
 import { useForm, FormProvider } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -17,7 +18,14 @@ import Modal from '@/components/Modal';
 import { useErrorModal } from '@/hooks/useErrorModal';
 import OptionSelect from '@/components/List/OptionSelect';
 import Loading from '@/components/Loading';
-import ImagesForm from '../../review/_components/form/ImagesForm';
+
+// FIXME: 이유를 알 수 없지만 해당 컴포넌트가 SSR 로 import 가 되어, 강제로 CSR import 로 변환
+const ImagesForm = dynamic(
+  () => import('../../review/_components/form/ImagesForm'),
+  {
+    ssr: false,
+  },
+);
 
 const TYPE_OPTIONS = [
   {
@@ -179,9 +187,11 @@ export default function InquireRegister() {
               ({watch('content')?.length} / 1000)
             </div>
           </article>
+
           <article className="m-5 pb-5 border-b-[0.01rem] border-mainGray">
             <ImagesForm />
           </article>
+
           <article className="mx-5 space-y-9">
             <Button onClick={handleSubmit(onSave)} btnName="전송" />
           </article>

--- a/src/app/(primary)/review/_components/form/ImagesForm.tsx
+++ b/src/app/(primary)/review/_components/form/ImagesForm.tsx
@@ -17,12 +17,8 @@ export default function ImagesForm() {
   const [savedImages, setSavedImages] = useState<SaveImages[]>([]);
   const [forceOpen, setForceOpen] = useState(false);
 
-  async function handleUploadImg(data: File) {
-    console.log(data);
-  }
-
-  const onUploadPreview = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newFiles = e.target.files;
+  const onUploadPreview = (imgData: File) => {
+    const newFiles = [imgData];
 
     if (newFiles && newFiles.length > 0) {
       // 이미지 미리보기용
@@ -82,7 +78,7 @@ export default function ImagesForm() {
   };
 
   const { handleOpenAlbum } = useWebviewCamera({
-    handleImg: handleUploadImg,
+    handleImg: onUploadPreview,
   });
 
   const onClickAddImage = () => {
@@ -123,8 +119,14 @@ export default function ImagesForm() {
           accept="image/*"
           hidden
           ref={imageRefModify}
-          onChange={(e) => {
-            onUploadPreview(e);
+          onChange={(event) => {
+            const fileInput = event.target;
+            const file = fileInput.files?.[0];
+
+            if (file) {
+              onUploadPreview(file);
+              fileInput.value = '';
+            }
             setForceOpen(true);
           }}
           multiple
@@ -171,6 +173,7 @@ export default function ImagesForm() {
             </button>
           </figure>
         ))}
+
         {previewImages?.length < 5 && (
           <button
             onClick={onClickAddImage}
@@ -187,7 +190,16 @@ export default function ImagesForm() {
               accept="image/*"
               hidden
               ref={imageRef}
-              onChange={onUploadPreview}
+              onChange={(event) => {
+                const fileInput = event.target;
+                const file = fileInput.files?.[0];
+
+                if (file) {
+                  onUploadPreview(file);
+                  fileInput.value = '';
+                }
+                setForceOpen(true);
+              }}
               multiple
             />
           </button>

--- a/src/app/(primary)/review/_components/form/ImagesForm.tsx
+++ b/src/app/(primary)/review/_components/form/ImagesForm.tsx
@@ -4,15 +4,22 @@ import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import { useFormContext } from 'react-hook-form';
 import { SaveImages } from '@/types/Image';
+import { useWebViewInit } from '@/hooks/useWebViewInit';
+import { useWebviewCamera } from '@/hooks/useWebviewCamera';
 import OptionsContainer from '../OptionsContainer';
 
 export default function ImagesForm() {
   const imageRef = useRef<HTMLInputElement>(null);
   const imageRefModify = useRef<HTMLInputElement>(null);
   const { setValue, watch } = useFormContext();
+  const { isMobile } = useWebViewInit();
   const [previewImages, setPreviewImages] = useState<SaveImages[]>([]);
   const [savedImages, setSavedImages] = useState<SaveImages[]>([]);
   const [forceOpen, setForceOpen] = useState(false);
+
+  async function handleUploadImg(data: File) {
+    console.log(data);
+  }
 
   const onUploadPreview = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newFiles = e.target.files;
@@ -74,6 +81,15 @@ export default function ImagesForm() {
     setPreviewImages(updatedPreviews);
   };
 
+  const { handleOpenAlbum } = useWebviewCamera({
+    handleImg: handleUploadImg,
+  });
+
+  const onClickAddImage = () => {
+    if (isMobile) return handleOpenAlbum();
+    return imageRef.current?.click();
+  };
+
   useEffect(() => {
     if (watch('imageUrlList')) {
       const urlData = watch('imageUrlList').map(
@@ -88,6 +104,10 @@ export default function ImagesForm() {
       setPreviewImages(urlData);
     }
   }, []);
+
+  useEffect(() => {
+    forceOpen && setForceOpen(false);
+  }, [previewImages, forceOpen]);
 
   const ExtraButtons = (
     <div className="flex items-center">
@@ -112,10 +132,6 @@ export default function ImagesForm() {
       </button>
     </div>
   );
-
-  useEffect(() => {
-    forceOpen && setForceOpen(false);
-  }, [previewImages, forceOpen]);
 
   return (
     <OptionsContainer
@@ -157,7 +173,7 @@ export default function ImagesForm() {
         ))}
         {previewImages?.length < 5 && (
           <button
-            onClick={() => imageRef.current?.click()}
+            onClick={onClickAddImage}
             className="h-[3.8rem] w-[3.8rem] border border-subCoral flex flex-col justify-center items-center"
           >
             <Image
@@ -177,7 +193,6 @@ export default function ImagesForm() {
           </button>
         )}
       </div>
-      {/* )} */}
     </OptionsContainer>
   );
 }


### PR DESCRIPTION
### PR 제목 (Title)

* #256

### 변경 사항 (Changes)

* 플러터 앨범 핸들링 함수 ImagesForm 컴포넌트 적용
* /inquire/register 경로에서 ImagesForm 이 ssr 로 적용되어, dynamic 으로 CSR 로 변환 (원인 모름)

### 변경 이유 (Reason for Changes)

* 이미지 등록도 핵심 기능이니깐...

### 테스트 방법 (Test Procedure)

- 위스키 하나 들어가서 리뷰를 남길 때 사진을 올려본다.

### 참고 사항 (Additional Information)

* 한번에 사진 여러장 올리는건 안됨요 ㅠ 플러터 로직 수정해야돼요
* 현재 플러터에서 앨범에서 사진 하나 선택 -> base64 변환 -> 웹뷰로 쏨 이라서 여러개 핸들링이 안됌
