### PR TITLE
[#262] 소셜로그인 심사 대응 - 테스트 이후 로그인 버튼 복구 / 베이직 로그인 - 탈퇴 회원 재가입 처리

### DIFF
--- a/src/app/(custom)/login/_components/SocialLoginBtn.tsx
+++ b/src/app/(custom)/login/_components/SocialLoginBtn.tsx
@@ -44,6 +44,16 @@ function SocialLoginBtn({ type, onClick }: Props) {
           <span>Apple로 로그인</span>
         </div>
       )}
+      {type === 'GOOGLE' && (
+        <div className="flex justify-center relative bg-white">
+          <span>구글로 로그인</span>
+        </div>
+      )}
+      {type === 'NAVER' && (
+        <div className="flex justify-center relative bg-white">
+          <span>네이버로 로그인</span>
+        </div>
+      )}
     </button>
   );
 }

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -213,8 +213,9 @@ export default function Login() {
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={kakaoLoginHandler} />
             <SocialLoginBtn type="APPLE" onClick={() => signIn('apple')} />
-            <SocialLoginBtn type="GOOGLE" onClick={() => signIn('google')} />
-            <SocialLoginBtn type="NAVER" onClick={() => signIn('naver')} />
+            {/* NOTE: 소셜로그인 테스트용 계정 */}
+            {/* <SocialLoginBtn type="GOOGLE" onClick={() => signIn('google')} /> */}
+            {/* <SocialLoginBtn type="NAVER" onClick={() => signIn('naver')} /> */}
           </article>
         </section>
 

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -14,6 +14,7 @@ import { AuthApi } from '@/app/api/AuthApi';
 import { UserData } from '@/types/Auth';
 import Modal from '@/components/Modal';
 import useModalStore from '@/store/modalStore';
+import { ApiError } from '@/utils/ApiError';
 import SocialLoginBtn from './_components/SocialLoginBtn';
 import LogoWhite from 'public/bottle_note_logo_white.svg';
 
@@ -33,6 +34,29 @@ export default function Login() {
 
   const { register, handleSubmit } = useForm<FormValues>();
 
+  const handleRestore = async (data: FormValues) => {
+    try {
+      await AuthApi.restore(data);
+      handleModalState({
+        isShowModal: true,
+        type: 'ALERT',
+        mainText: `재가입에 성공하였습니다.`,
+        handleConfirm: () => {
+          handleCloseModal();
+        },
+      });
+    } catch (error) {
+      handleModalState({
+        isShowModal: true,
+        type: 'ALERT',
+        mainText: `${(error as unknown as ApiError).message}`,
+        handleConfirm: () => {
+          handleCloseModal();
+        },
+      });
+    }
+  };
+
   const handleLogin = async (data: FormValues) => {
     try {
       const result = await AuthApi.basicLogin(data);
@@ -45,10 +69,22 @@ export default function Login() {
       });
 
       router.push('/');
-    } catch (e) {
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'USER_DELETED') {
+        return handleModalState({
+          isShowModal: true,
+          type: 'CONFIRM',
+          mainText: `${`탈퇴한 유저입니다. 재가입하시겠습니까?`}`,
+          handleConfirm: async () => {
+            handleCloseModal();
+            await handleRestore(data);
+          },
+        });
+      }
+
       handleModalState({
         isShowModal: true,
-        mainText: `${(e as unknown as Error).message}`,
+        mainText: `${(error as unknown as Error).message}`,
         handleConfirm: () => {
           handleCloseModal();
         },

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -204,7 +204,7 @@ export default function Login() {
             </button>
           </form>
 
-          {/* <article className="flex gap-2 items-center py-2">
+          <article className="flex gap-2 items-center py-2">
             <div className="w-full h-[1px] bg-white" />
             <span className="text-xs text-white shrink-0">또는</span>
             <div className="w-full h-[1px] bg-white" />
@@ -213,7 +213,9 @@ export default function Login() {
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={kakaoLoginHandler} />
             <SocialLoginBtn type="APPLE" onClick={() => signIn('apple')} />
-          </article> */}
+            <SocialLoginBtn type="GOOGLE" onClick={() => signIn('google')} />
+            <SocialLoginBtn type="NAVER" onClick={() => signIn('naver')} />
+          </article>
         </section>
 
         <footer className="border-t border-white w-full pt-2">

--- a/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
+++ b/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
@@ -79,6 +79,7 @@ const SidebarHeader = () => {
   const handleLogout = async () => {
     logout();
     if (session) await signOut({ callbackUrl: '/', redirect: true });
+    handleCloseModal();
     route.push('/');
   };
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -9,6 +9,7 @@ import { AuthApi } from '../../AuthApi';
 const jwt = require('jsonwebtoken');
 
 const handler = NextAuth({
+  debug: true,
   providers: [
     GoogleProvider({
       clientId: `${process.env.GOOGLE_CLIENT_ID}`,

--- a/src/utils/ApiError.ts
+++ b/src/utils/ApiError.ts
@@ -1,8 +1,11 @@
 export class ApiError extends Error {
   response: Response;
 
-  constructor(message: string, response: Response) {
+  code: string | null = null;
+
+  constructor(message: string, response: Response, code?: string) {
     super(message);
     this.response = response;
+    this.code = code || null;
   }
 }

--- a/src/utils/getAppleToken.ts
+++ b/src/utils/getAppleToken.ts
@@ -2,7 +2,10 @@ import { createPrivateKey } from 'crypto';
 import { SignJWT } from 'jose';
 
 export const getAppleToken = async () => {
-  const key = `-----BEGIN PRIVATE KEY-----\n${process.env.APPLE_KEY}\n-----END PRIVATE KEY-----\n`;
+  const keyContent = Buffer.from(process.env.APPLE_KEY!, 'base64').toString(
+    'utf-8',
+  );
+  const key = `-----BEGIN PRIVATE KEY-----\n${keyContent}\n-----END PRIVATE KEY-----`;
 
   const teamId = process.env.APPLE_TEAM_ID!;
   const appleId = process.env.APPLE_ID!;


### PR DESCRIPTION
### PR 제목 (Title)

* PR과 관련된 간단한 제목을 작성해주세요.

### 변경 사항 (Changes)

- [x] 테스트 이후 소셜 로그인 버튼 재활성화
  - [x] nextAuth 애플 키 처리 로직 수정 
- [x] 탈퇴 후 재가입 처리 (베이직 로그인)

### 변경 이유 (Reason for Changes)

* 버셀 계정으로 테스트했을 때 애플 키 쪽 변경사항 적용 후 정상 로그인 확인
* 실제 로그인 되는지는 다시 올려봐야 알 수 있음 흑흑
* 탈퇴 후 재가입 - 구글 심사 대응 추가

### 테스트 방법 (Test Procedure)

* 로그인 페이지 > 소셜 로그인 확인
* 베이직 로그인 탈퇴처리 > 재로그인

### 참고 사항 (Additional Information)

* 소셜 로그인 탈퇴 회원 재가입의 경우 nextAuth 쪽 응답 로직 수정이 필요해 다시 PR 날리겠습니다.
