### PR TITLE
[Hotfix]: 모달 닫혔을 때, 이전 모달에 떠있던 subText 남아있는 현상

### DIFF
--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -54,7 +54,9 @@ const useModalStore = create<ModalStore>((set) => ({
       },
     })),
   handleCloseModal: () => {
-    set((state) => ({ state: { ...state.state, isShowModal: false } }));
+    set((state) => ({
+      state: { ...state.state, mainText: '', subText: '', isShowModal: false },
+    }));
   },
   handleLoginModal: () =>
     set((state) => ({


### PR DESCRIPTION
### PR 제목 (Title)

모달 닫혔을 때, 이전 모달에 떠있던 subText 남아있는 현상

### 변경 사항 (Changes)
- [x] 모달창 닫힐 때 모든 text 함께 reset

### 변경 이유 (Reason for Changes)

![image](https://github.com/user-attachments/assets/4b25468f-9419-4335-a819-0a6ebdfe7158)

### 테스트 방법 (Test Procedure)

* 이 변경을 테스트하기 위한 절차를 설명해주세요.
* 예: 어떤 환경에서 테스트를 수행했는지, 어떤 방식으로 테스트를 진행했는지 등

### 참고 사항 (Additional Information)

* PR과 관련된 추가적인 정보가 있다면 여기에 기술해주세요.
