### PR TITLE
[#273] 팔로잉 페이지 변경된 api spec 적용

### DIFF
--- a/src/app/(primary)/user/[id]/_components/FollowerListItem.tsx
+++ b/src/app/(primary)/user/[id]/_components/FollowerListItem.tsx
@@ -28,7 +28,7 @@ export const FollowerListItem = ({ userInfo }: Props) => {
           className="rounded-full"
         />
         <div className="flex flex-col gap-1">
-          <p className="text-12 font-bold">{userInfo.nickName}</p>
+          <p className="text-12 font-bold">{userInfo.followUserNickname}</p>
           <p className="text-10 text-brightGray font-semibold flex gap-2">
             <span className="flex gap-1">
               <Image src={CommentGray} alt="리뷰" width={12} height={12} />

--- a/src/app/(primary)/user/[id]/_components/UserInfo.tsx
+++ b/src/app/(primary)/user/[id]/_components/UserInfo.tsx
@@ -24,11 +24,11 @@ const UserInfo = ({
   nickName,
 }: Props) => {
   const { userData } = AuthService;
-  const [isMatchUser, setIsMatchUser] = useState(false);
+  const [isMyProfile, setIsMyProfile] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
-    setIsMatchUser(userData?.userId === Number(currentId));
+    setIsMyProfile(userData?.userId === Number(currentId));
   }, []);
 
   return (
@@ -63,7 +63,7 @@ const UserInfo = ({
         </div>
 
         <div className="space-x-1 text-sm">
-          {isMatchUser && (
+          {isMyProfile && (
             <button
               className="border border-subCoral px-2.5 py-1 rounded-md text-10 bg-white text-subCoral"
               onClick={() => router.push(`/user/${currentId}/edit`)}
@@ -72,10 +72,10 @@ const UserInfo = ({
             </button>
           )}
 
-          {!isMatchUser && (
+          {!isMyProfile && (
             <FollowButton
               isFollowing={Boolean(isFollowing)}
-              followUserId={userData?.userId!}
+              followUserId={Number(currentId)}
             />
           )}
         </div>

--- a/src/app/(primary)/user/[id]/follow/page.tsx
+++ b/src/app/(primary)/user/[id]/follow/page.tsx
@@ -24,7 +24,7 @@ export default function UserFollowPage({
     tabList: [
       { name: '팔로잉', id: 'following' },
       { name: '팔로워', id: 'follower' },
-    ],
+    ] as const,
   });
 
   const {
@@ -37,10 +37,11 @@ export default function UserFollowPage({
     followerList: RelationInfo[];
     totalCount: number;
   }>({
-    queryKey: ['follow'],
+    queryKey: ['follow', currentTab.id],
     queryFn: () => {
       return UserApi.getRelationList({
         userId: Number(userId),
+        type: currentTab.id,
       });
     },
   });
@@ -93,8 +94,11 @@ export default function UserFollowPage({
               <ListSection className="flex flex-col">
                 {relationList[0].data.followingList
                   .flat()
-                  .map((item: RelationInfo) => (
-                    <FollowerListItem key={item.userId} userInfo={item} />
+                  .map((item: RelationInfo, idx) => (
+                    <FollowerListItem
+                      key={`${item.userId}_${idx}`}
+                      userInfo={item}
+                    />
                   ))}
               </ListSection>
             </List>
@@ -116,8 +120,11 @@ export default function UserFollowPage({
               <ListSection className="flex flex-col">
                 {relationList[0].data.followerList
                   .flat()
-                  .map((item: RelationInfo) => (
-                    <FollowerListItem key={item.userId} userInfo={item} />
+                  .map((item: RelationInfo, idx) => (
+                    <FollowerListItem
+                      key={`${item.userId}_${idx}`}
+                      userInfo={item}
+                    />
                   ))}
               </ListSection>
             </List>

--- a/src/app/(primary)/user/[id]/follow/page.tsx
+++ b/src/app/(primary)/user/[id]/follow/page.tsx
@@ -97,7 +97,7 @@ export default function UserFollowPage({
                   .map((item: RelationInfo, idx) => (
                     <FollowerListItem
                       key={`${item.userId}_${idx}`}
-                      userInfo={item}
+                      userInfo={{ ...item, userId: item.followUserId }}
                     />
                   ))}
               </ListSection>

--- a/src/app/(primary)/user/[id]/follow/page.tsx
+++ b/src/app/(primary)/user/[id]/follow/page.tsx
@@ -19,7 +19,7 @@ export default function UserFollowPage({
   params: { id: string };
 }) {
   const router = useRouter();
-  const historyType = useSearchParams().get('type') ?? 'following';
+  const currTapType = useSearchParams().get('type') ?? 'following';
   const { currentTab, handleTab, tabList } = useTab({
     tabList: [
       { name: '팔로잉', id: 'following' },
@@ -33,8 +33,8 @@ export default function UserFollowPage({
     isFetching,
     targetRef,
   } = usePaginatedQuery<{
-    followingList: RelationInfo[];
-    followerList: RelationInfo[];
+    followingList?: RelationInfo[];
+    followerList?: RelationInfo[];
     totalCount: number;
   }>({
     queryKey: ['follow', currentTab.id],
@@ -47,8 +47,8 @@ export default function UserFollowPage({
   });
 
   useEffect(() => {
-    handleTab(historyType);
-  }, [historyType]);
+    handleTab(currTapType);
+  }, []);
 
   return (
     <Suspense>
@@ -87,13 +87,13 @@ export default function UserFollowPage({
             >
               <List.Title title="내가 팔로우 하는 유저" />
               <List.Total
-                total={relationList[0].data.followingList.length}
+                total={relationList[0].data.followingList?.length ?? 0}
                 unit="명"
               />
 
               <ListSection className="flex flex-col">
                 {relationList[0].data.followingList
-                  .flat()
+                  ?.flat()
                   .map((item: RelationInfo, idx) => (
                     <FollowerListItem
                       key={`${item.userId}_${idx}`}
@@ -101,6 +101,7 @@ export default function UserFollowPage({
                     />
                   ))}
               </ListSection>
+              <div ref={targetRef} />
             </List>
           )}
 
@@ -113,13 +114,13 @@ export default function UserFollowPage({
             >
               <List.Title title="나를 팔로우 하는 유저" />
               <List.Total
-                total={relationList[0].data.followerList.length}
+                total={relationList[0].data.followerList?.length ?? 0}
                 unit="명"
               />
 
               <ListSection className="flex flex-col">
                 {relationList[0].data.followerList
-                  .flat()
+                  ?.flat()
                   .map((item: RelationInfo, idx) => (
                     <FollowerListItem
                       key={`${item.userId}_${idx}`}
@@ -127,10 +128,9 @@ export default function UserFollowPage({
                     />
                   ))}
               </ListSection>
+              <div ref={targetRef} />
             </List>
           )}
-
-          <div ref={targetRef} />
         </section>
       </main>
     </Suspense>

--- a/src/app/api/UserApi.ts
+++ b/src/app/api/UserApi.ts
@@ -124,12 +124,18 @@ export const UserApi = {
     return result;
   },
 
-  async getRelationList({ userId }: { userId: number }) {
+  async getRelationList({
+    userId,
+    type,
+  }: {
+    userId: number;
+    type: 'follower' | 'following';
+  }) {
     const response: ApiResponse<{
       followingList: RelationInfo[];
       followerList: RelationInfo[];
       totalCount: number;
-    }> = await fetchWithAuth(`/bottle-api/follow/${userId}/relation-list`);
+    }> = await fetchWithAuth(`/bottle-api/follow/${userId}/${type}-list`);
 
     if (!response.data) {
       throw new Error('Failed to fetch data');

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -12,6 +12,7 @@ interface Props {
   options?: Options;
 }
 
+// TODO: 감지되는 타이밍이 조금 더 이르게 되도록 threshold 값 수정
 export const useInfiniteScroll = ({ fetchNextPage, options }: Props) => {
   const targetRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 
-interface Props {
-  tabList: { name: string; id: string }[];
+interface Props<T> {
+  tabList: T[];
 }
 
-export const useTab = ({ tabList }: Props) => {
+export const useTab = <T extends { name: string; id: string }>({
+  tabList,
+}: Props<T>) => {
   const [currentTab, setCurrentTab] = useState(tabList[0]);
 
   const handleTab = (id: string) => {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -20,7 +20,7 @@ export interface ReviewUserInfo extends Omit<User, 'imageUrl'> {
 export interface RelationInfo {
   userId: number;
   followUserId: number;
-  nickName: string;
+  followUserNickname: string;
   userProfileImage: string;
   status: 'UNFOLLOW' | 'FOLLOWING';
   reviewCount: number;


### PR DESCRIPTION
### PR 제목 (Title)

* [#273]

### 변경 사항 (Changes)

- [x] 팔로잉, 팔로우 유저 조회 분리된 엔드포인트 적용
- [x] 팔로잉/팔로우 유저 마이페이지 이동시 유저 아이디 매칭 이슈 수정

### 변경 이유 (Reason for Changes)

- api 스펙 변동 및 팔로잉/팔로우 조회인지에 따라서 값을 묘하게 다르게 내려줘서 수정해줌

### 참고 사항 (Additional Information)

* 팔로우를 했음에도 팔로잉 상태로 변경안되고, 팔로우를 해제했음에도 팔로잉 해제 상태로 변경이 안되는 것은
* 서버에서 조회중인 유저 기준으로 status 를 내려줘야 하는데
* 리스트에 나와있는 유저 기준으로 상태를 줘서 그러함. 수정 예정이라고 하심