### PR TITLE
리뷰, home, history QC

### DIFF
--- a/src/app/(primary)/_components/HotList.tsx
+++ b/src/app/(primary)/_components/HotList.tsx
@@ -9,14 +9,12 @@ function HotList() {
   return (
     <>
       {popularList.length !== 0 && (
-        <div className="whitespace-nowrap overflow-x-auto flex space-x-2 scrollbar-hide">
-          {popularList.map((item) => {
-            return (
-              <div key={item.alcoholId} className="flex-shrink-0">
-                <HorizontalItem data={item} />
-              </div>
-            );
-          })}
+        <div className="whitespace-nowrap overflow-x-auto overflow-y-hidden flex space-x-2 scrollbar-hide">
+          {popularList.map((item) => (
+            <div key={item.alcoholId} className="flex-shrink-0 flex-grow-0">
+              <HorizontalItem data={item} />
+            </div>
+          ))}
         </div>
       )}
     </>

--- a/src/app/(primary)/_components/PickBtn.tsx
+++ b/src/app/(primary)/_components/PickBtn.tsx
@@ -71,7 +71,7 @@ const PickBtn = ({
           alt="unPick"
         />
       )}
-      {pickBtnName && <p className="text-12 font-bold">{pickBtnName}</p>}
+      {pickBtnName && <p className="text-12 font-normal">{pickBtnName}</p>}
     </button>
   );
 };

--- a/src/app/(primary)/_components/TimeLineItem.tsx
+++ b/src/app/(primary)/_components/TimeLineItem.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionProps,
 } from '@/app/(primary)/history/_components/filter/HistoryDescription';
 import { formatDate } from '@/utils/formatDate';
+import { truncStr } from '@/utils/truncStr';
 import { TimeFormat } from '@/types/FormatDate';
 import { Rate } from '@/types/History';
 
@@ -82,7 +83,7 @@ function TimeLineItem(props: Props) {
           <div className="w-[17rem] h-14 p-3 bg-bgGray rounded-md flex justify-between">
             <div>
               <p className="text-12 font-bold text-mainDarkGray">
-                {alcoholName}
+                {truncStr(alcoholName, 23)}
               </p>
               {renderDescription && renderDescription(getDescriptionProps())}
             </div>

--- a/src/app/(primary)/history/page.tsx
+++ b/src/app/(primary)/history/page.tsx
@@ -21,10 +21,10 @@ import {
 } from '@/types/History';
 import { RATING_NUM_VALUES, PICKS_STATUS } from '@/constants/history';
 import { groupHistoryByDate, shouldShowDivider } from '@/utils/historyUtils';
+import { CurrentUserInfoApi } from '@/types/User';
 import FilterSideModal from './_components/filter/FilterSideModal';
 import { HistoryEmptyState } from './_components/HistoryEmptyState';
 import FilterIcon from 'public/icon/filter-subcoral.svg';
-import { CurrentUserInfoApi } from '@/types/User';
 
 export default function History() {
   const queryClient = useQueryClient();

--- a/src/app/(primary)/history/page.tsx
+++ b/src/app/(primary)/history/page.tsx
@@ -113,24 +113,9 @@ export default function History() {
 
   const dataChecking =
     historyData &&
-    !historyData[0].meta?.pageable?.hasNext &&
+    historyData[0].data?.userHistories?.length > 0 &&
     !error &&
     !isLoading;
-
-  useEffect(() => {
-    if (!historyData) return;
-
-    const historyList = historyData.flatMap((page) => page.data.userHistories);
-    const groupedHistory = groupHistoryByDate(historyList);
-    const yearMonths = Object.keys(groupedHistory).sort((a, b) =>
-      b.localeCompare(a),
-    );
-
-    setProcessedHistory({
-      groupedHistory,
-      yearMonths,
-    });
-  }, [historyData]);
 
   const { groupedHistory, yearMonths } = processedHistory;
 
@@ -282,7 +267,11 @@ export default function History() {
                       </div>
                       <TimeLineItem
                         isStart
-                        date={historyData[0].data.subscriptionDate}
+                        date={
+                          (historyData &&
+                            historyData[0].data?.subscriptionDate) ||
+                          ''
+                        }
                         type="BOTTLE"
                       />
                     </div>

--- a/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
+++ b/src/app/(primary)/review/[id]/_components/AlcoholInfo.tsx
@@ -50,7 +50,7 @@ function AlcoholInfo({ data, handleLogin }: Props) {
             <h1 className="text-15 font-semibold whitespace-normal break-words">
               {data.korName && truncStr(data.korName, 27)}
             </h1>
-            <p className="text-13 whitespace-normal break-words">
+            <p className="text-12 whitespace-normal break-words font-normal">
               {data.engName && truncStr(data.engName.toUpperCase(), 45)}
             </p>
           </div>
@@ -58,7 +58,7 @@ function AlcoholInfo({ data, handleLogin }: Props) {
             <div className="border-[0.5px] border-white" />
             <div className="flex space-x-3">
               <div
-                className="text-12 font-bold flex"
+                className="text-12 font-normal flex"
                 onClick={handleLoginConfirm}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {

--- a/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
+++ b/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
@@ -104,14 +104,14 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
               <Label
                 name="베스트"
                 icon="/icon/thumbup-filled-white.svg"
-                styleClass="bg-mainCoral text-white px-2 py-[0.1rem] border-mainCoral text-9 rounded"
+                styleClass="bg-mainCoral text-white px-2 py-[0.1rem] border-mainCoral text-10 rounded"
               />
             )}
             {data.reviewInfo?.isMyReview && (
               <Label
                 name="나의 코멘트"
                 icon="/icon/user-outlined-subcoral.svg"
-                styleClass="border-mainCoral text-mainCoral px-2 py-[0.1rem] text-9 rounded"
+                styleClass="border-mainCoral text-mainCoral px-2 py-[0.1rem] text-10 rounded"
               />
             )}
             {data.reviewInfo?.userInfo?.userId === userData?.userId && (
@@ -139,12 +139,12 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
               ))}
             </div>
           )}
-          <div className="text-13 text-mainDarkGray">
+          <div className="text-12 text-mainDarkGray">
             {data.reviewInfo?.reviewContent}
           </div>
           <article className="flex justify-between">
             {data.reviewInfo?.createAt && (
-              <p className="text-mainGray text-11">
+              <p className="text-mainGray text-10">
                 {formatDate(data.reviewInfo.createAt) as string}
               </p>
             )}
@@ -189,12 +189,12 @@ function ReviewDetails({ data, handleLogin, textareaRef }: Props) {
                       : 'Glass Price'
                   }
                 />
-                <p className="text-mainDarkGray font-semibold">
+                <p className="text-mainDarkGray font-normal">
                   {data.reviewInfo.sizeType === 'BOTTLE'
                     ? '병 가격 '
                     : '잔 가격'}
                 </p>
-                <p className="text-mainDarkGray font-light">
+                <p className="text-mainDarkGray font-normal">
                   {numberWithCommas(data.reviewInfo.price)}₩
                 </p>
               </div>

--- a/src/app/(primary)/search/[category]/[id]/_components/AlcoholBox.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/AlcoholBox.tsx
@@ -42,7 +42,7 @@ function AlcoholBox({ data, isPicked, setIsPicked }: Props) {
               <h1 className="text-20 font-semibold whitespace-normal break-words">
                 {data.korName && truncStr(data.korName, 27)}
               </h1>
-              <p className="text-13 whitespace-normal break-words">
+              <p className="text-12 whitespace-normal break-words">
                 {data.engName && truncStr(data.engName.toUpperCase(), 45)}
               </p>
             </div>

--- a/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
@@ -31,7 +31,7 @@ function Review({ data }: Props) {
   const { state, handleModalState, handleLoginModal } = useModalStore();
   const [isOptionShow, setIsOptionShow] = useState(false);
   const [isLiked, setIsLiked] = useState(isLikedByMe);
-  // const [currentStatus, setCurrentStatus] = useState(data.status === 'PUBLIC');
+  const [currentStatus, setCurrentStatus] = useState(data.status === 'PUBLIC');
 
   const handleCloseOption = () => {
     handleModalState({
@@ -68,9 +68,9 @@ function Review({ data }: Props) {
     }
   };
 
-  // useEffect(() => {
-  //   setCurrentStatus(data.status === 'PUBLIC');
-  // }, [data.status]);
+  useEffect(() => {
+    setCurrentStatus(data.status === 'PUBLIC');
+  }, [data.status]);
 
   return (
     <>
@@ -105,7 +105,7 @@ function Review({ data }: Props) {
                 name="나의 코멘트"
                 icon="/icon/user-outlined-subcoral.svg"
                 iconHeight={10}
-                styleClass="border-mainCoral text-mainCoral px-2 py-[0.1rem] text-9 rounded"
+                styleClass="border-mainCoral text-mainCoral px-2 py-[0.1rem] text-10 rounded"
               />
             )}
           </div>
@@ -122,15 +122,15 @@ function Review({ data }: Props) {
             height={12}
             alt={data.sizeType === 'BOTTLE' ? 'Bottle Price' : 'Glass Price'}
           />
-          <p className="text-mainGray text-10 font-semibold">
+          <p className="text-mainGray text-12 font-semibold">
             {data.sizeType === 'BOTTLE' ? '병 가격 ' : '잔 가격'}
           </p>
-          <p className="text-mainGray text-10 font-light">
+          <p className="text-mainGray text-12 font-normal">
             {data.price ? `${numberWithCommas(data.price)} ₩` : '-'}
           </p>
         </div>
         <div className="grid grid-cols-5 space-x-2">
-          <p className="col-span-4 text-mainDarkGray text-10">
+          <p className="col-span-4 text-mainDarkGray text-12">
             <Link href={`/review/${data.reviewId}`}>
               {truncStr(data.reviewContent, 135)}
               {data.reviewContent.length > 135 && (
@@ -150,7 +150,7 @@ function Review({ data }: Props) {
             </div>
           )}
         </div>
-        <div className="flex justify-between text-9 text-mainGray">
+        <div className="flex justify-between text-11 text-mainGray">
           <div className="flex space-x-3">
             <div className="flex items-center space-x-1">
               <LikeBtn
@@ -180,14 +180,14 @@ function Review({ data }: Props) {
             </div>
             {data.userInfo.userId === userData?.userId && (
               <VisibilityToggle
-                initialStatus={data.status === 'PUBLIC'}
+                initialStatus={currentStatus}
                 reviewId={data.reviewId}
                 handleNotLogin={handleLoginModal}
               />
             )}
           </div>
           <div className="flex items-center">
-            <p className="text-9">{formatDate(data.createAt) as string}</p>
+            <p className="text-10">{formatDate(data.createAt) as string}</p>
             <button
               className="cursor-pointer"
               onClick={() => {

--- a/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
@@ -17,7 +17,8 @@ import Modal from '@/components/Modal';
 import useModalStore from '@/store/modalStore';
 import { deleteReview } from '@/lib/Review';
 import { AuthService } from '@/lib/AuthService';
-import userImg from 'public/profile-default.svg';
+
+const DEFAULT_USER_IMAGE = '/profile-default.svg';
 
 interface Props {
   data: ReviewType;
@@ -30,7 +31,7 @@ function Review({ data }: Props) {
   const { state, handleModalState, handleLoginModal } = useModalStore();
   const [isOptionShow, setIsOptionShow] = useState(false);
   const [isLiked, setIsLiked] = useState(isLikedByMe);
-  const [currentStatus, setCurrentStatus] = useState(data.status === 'PUBLIC');
+  // const [currentStatus, setCurrentStatus] = useState(data.status === 'PUBLIC');
 
   const handleCloseOption = () => {
     handleModalState({
@@ -67,9 +68,9 @@ function Review({ data }: Props) {
     }
   };
 
-  useEffect(() => {
-    setCurrentStatus(data.status === 'PUBLIC');
-  }, [data.status]);
+  // useEffect(() => {
+  //   setCurrentStatus(data.status === 'PUBLIC');
+  // }, [data.status]);
 
   return (
     <>
@@ -81,7 +82,7 @@ function Review({ data }: Props) {
                 <div className="w-7 h-7 rounded-full overflow-hidden">
                   <Image
                     className="object-cover"
-                    src={data.userInfo.userProfileImage || userImg}
+                    src={data.userInfo.userProfileImage || DEFAULT_USER_IMAGE}
                     alt="user_img"
                     width={28}
                     height={28}
@@ -179,7 +180,7 @@ function Review({ data }: Props) {
             </div>
             {data.userInfo.userId === userData?.userId && (
               <VisibilityToggle
-                initialStatus={currentStatus}
+                initialStatus={data.status === 'PUBLIC'}
                 reviewId={data.reviewId}
                 handleNotLogin={handleLoginModal}
               />

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -204,10 +204,10 @@ function SearchAlcohol() {
                 {alcoholDetails.map((item: DetailItem) => (
                   <div
                     key={item.content}
-                    className="flex text-13 text-mainDarkGray items-start gap-2"
+                    className="flex text-12 text-mainDarkGray items-start gap-2"
                   >
                     <div className="min-w-14 font-semibold">{item.title}</div>
-                    <div className="flex-1 font-light">{item.content}</div>
+                    <div className="flex-1 font-normal">{item.content}</div>
                   </div>
                 ))}
               </section>

--- a/src/app/(primary)/search/[category]/[id]/reviews/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/reviews/page.tsx
@@ -2,8 +2,8 @@
 
 import React, { useState } from 'react';
 import Image from 'next/image';
-import { v4 as uuidv4 } from 'uuid';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
 import { ReviewApi } from '@/app/api/ReviewApi';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
 import { Review as ReviewType } from '@/types/Review';

--- a/src/app/(primary)/search/[category]/[id]/reviews/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/reviews/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import Image from 'next/image';
+import { v4 as uuidv4 } from 'uuid';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { ReviewApi } from '@/app/api/ReviewApi';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
@@ -158,10 +159,7 @@ function Reviews() {
                     [...reviewList.map((list) => list.data.reviewList)]
                       .flat()
                       .map((item: ReviewType) => (
-                        <Review
-                          data={item}
-                          key={item.reviewId + item.userInfo.userId}
-                        />
+                        <Review data={item} key={uuidv4()} />
                       ))}
                 </List.Section>
               </List>
@@ -195,10 +193,7 @@ function Reviews() {
                     [...myReviewList.map((list) => list.data.reviewList)]
                       .flat()
                       .map((item: ReviewType) => (
-                        <Review
-                          data={item}
-                          key={item.reviewId + item.userInfo.userId}
-                        />
+                        <Review data={item} key={uuidv4()} />
                       ))}
                 </List.Section>
               </List>

--- a/src/app/(primary)/user/[id]/_components/Timeline.tsx
+++ b/src/app/(primary)/user/[id]/_components/Timeline.tsx
@@ -58,6 +58,7 @@ function Timeline() {
         pageSize: 10,
       });
     },
+    enabled: !!userId,
   });
 
   const historyList: History[] =

--- a/src/app/api/HistoryApi.ts
+++ b/src/app/api/HistoryApi.ts
@@ -10,7 +10,6 @@ export const HistoryApi = {
     const { userId, cursor, pageSize } = baseParams;
     const response = await fetchWithAuth(
       `/bottle-api/history/${userId}?cursor=${cursor}&pageSize=${pageSize}${filterParams ? `&${filterParams}` : ''}`,
-      { requireAuth: true },
     );
 
     if (response.errors.length !== 0) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
 import '@/style/globals.css';
 import { Providers } from '@/lib/Providers';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Bottle Note',
@@ -26,7 +23,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="touch-manipulation">
-      <body className={inter.className} suppressHydrationWarning>
+      <body suppressHydrationWarning>
         <Providers>
           <body className="relative">
             {children}

--- a/src/queries/usePaginatedQuery.ts
+++ b/src/queries/usePaginatedQuery.ts
@@ -7,6 +7,7 @@ interface Props<T> {
   queryFn: (params: any) => Promise<ApiResponse<T>>;
   pageSize?: number;
   staleTime?: number;
+  enabled?: boolean;
 }
 
 export const usePaginatedQuery = <T>({
@@ -14,6 +15,7 @@ export const usePaginatedQuery = <T>({
   queryFn,
   pageSize = 10,
   staleTime = 1000,
+  enabled = true,
 }: Props<T>) => {
   const {
     data,
@@ -36,6 +38,7 @@ export const usePaginatedQuery = <T>({
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     staleTime,
+    enabled,
   });
 
   const { targetRef } = useInfiniteScroll({

--- a/src/queries/usePaginatedQuery.ts
+++ b/src/queries/usePaginatedQuery.ts
@@ -6,16 +6,19 @@ interface Props<T> {
   queryKey: [string, ...Array<any>];
   queryFn: (params: any) => Promise<ApiResponse<T>>;
   pageSize?: number;
-  staleTime?: number;
+  // staleTime?: number;
   enabled?: boolean;
+  refetchOnMount?: boolean;
+  gcTime?: number;
 }
 
 export const usePaginatedQuery = <T>({
   queryKey,
   queryFn,
   pageSize = 10,
-  staleTime = 1000,
   enabled = true,
+  refetchOnMount = true,
+  gcTime = 0,
 }: Props<T>) => {
   const {
     data,
@@ -35,9 +38,9 @@ export const usePaginatedQuery = <T>({
       return null;
     },
     initialPageParam: 0,
-    refetchOnMount: false,
+    refetchOnMount,
     refetchOnWindowFocus: false,
-    staleTime,
+    gcTime,
     enabled,
   });
 

--- a/src/style/globals.css
+++ b/src/style/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/* app/globals.css */
+@import url('https://cdn.jsdelivr.net/gh/sunn-us/SUIT/fonts/variable/woff2/SUIT-Variable.css');
+
+:root {
+  --font-suit: 'SUIT Variable', sans-serif;
+}
+
+body {
+  font-family: var(--font-suit);
+}
+
 @layer base {
   input,
   textarea {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -4,7 +4,11 @@ export interface User {
   imageUrl: string;
 }
 
-export type CurrentUserInfoApi = Omit<User, 'nickName'> & { nickname: string };
+export interface CurrentUserInfoApi {
+  id: number;
+  nickname: string;
+  imageUrl: string;
+}
 
 export interface UserInfoApi extends User {
   reviewCount: number;

--- a/src/utils/fetchWithAuth.ts
+++ b/src/utils/fetchWithAuth.ts
@@ -5,6 +5,7 @@ import { AuthService } from '../lib/AuthService';
 
 interface FetchOptions extends RequestInit {
   requireAuth?: boolean;
+  cache?: RequestCache;
 }
 
 type FetchWithAuth = (
@@ -18,7 +19,7 @@ export const fetchWithAuth: FetchWithAuth = async (
   options = {},
   retryCount = 0,
 ) => {
-  const { requireAuth = true, ...fetchOptions } = options;
+  const { requireAuth = true, cache = 'no-store', ...fetchOptions } = options;
 
   const token = AuthService.getToken();
 
@@ -38,7 +39,10 @@ export const fetchWithAuth: FetchWithAuth = async (
   if (!token) {
     try {
       // 인증 없이 API 요청
-      const response = await fetch(requestUrl, { ...fetchOptions });
+      const response = await fetch(requestUrl, {
+        ...fetchOptions,
+        cache,
+      });
 
       // 응답이 실패한 경우 → 에러 응답을 저장
       if (!response.ok) {
@@ -59,6 +63,7 @@ export const fetchWithAuth: FetchWithAuth = async (
   // 인증이 필요한 요청의 기본 옵션 구성
   const defaultOptions = {
     ...fetchOptions,
+    cache,
     headers: {
       ...fetchOptions?.headers,
       Authorization: `Bearer ${token.accessToken}`,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['SUIT Variable', 'sans-serif'], // 기본 폰트로 설정
+      },
       fontSize: {
         '9': ['9px', '9px'],
         '10': ['10px', '14px'],


### PR DESCRIPTION
### PR 제목 (Title)

* [#324 ]
리뷰, home, history QC

### 변경 사항 (Changes)
- [x] 공통 - nextjs fetch 및 react-query에 cache 조건 추가
- [x] 공통 - 글꼴 suit 적용
- [x] 리뷰 - 전체적인 폰트 사이즈 피그마에 맞춰 변경
- [x] 히스토리 - user nickname 하드코딩된 부분 api 연결
- [x] 히스토리 - 리스트가 길어질 때 화면이 안나오는 오류 수정
- [x] 홈 - 위클리5 가로 스트롤만 되도록 수정

### 변경 이유 (Reason for Changes)
- cache의 경우, 별도 옵션을 주지 않으면 fetchWithAuth와 react-query 모두 캐시를 저장하게 되어 있어서 무조건 캐시를 날리고 화면에 진입하면 api 호출 하도록 수정 했습니다. 이후에 고도화하면서 cache, staleTime은 페이지에 맞게 수정하면 좋을 것 같아요.

### 테스트 방법 (Test Procedure)

- 각 페이지에서 확인 가능

### 참고 사항 (Additional Information)
- 리뷰 비공개, 공개 부분이 지금 문제가 좀 있는데 오늘 안에 해결이 가능할지 미지수라 된 부분들 먼저 pr 올립니다.