### PR TITLE
알콜 디테일 페이지 스타일 수정

### DIFF
--- a/src/app/(primary)/_components/AlcoholImage.tsx
+++ b/src/app/(primary)/_components/AlcoholImage.tsx
@@ -1,4 +1,8 @@
+'use client';
+
+import { useState } from 'react';
 import Image from 'next/image';
+import Fallback from 'public/bottle.svg';
 
 interface Props {
   imageUrl: string;
@@ -14,23 +18,28 @@ const AlcoholImage = ({
   outerWidthClass = 'w-[100px]',
   innerHeightClass = 'w-[80px] ',
   innerWidthClass = 'h-[140px]',
-}: Props) => (
-  <div className="rounded-lg bg-white flex items-center justify-center">
-    <article
-      className={`${outerHeightClass} ${outerWidthClass} shrink-0 relative flex items-center justify-center`}
-    >
-      <div className={`${innerHeightClass} ${innerWidthClass} relative`}>
-        <Image
-          priority
-          src={imageUrl}
-          alt="alcohol image"
-          fill
-          className="object-contain"
-          sizes="100px"
-        />
-      </div>
-    </article>
-  </div>
-);
+}: Props) => {
+  const [imgSrc, setImgSrc] = useState(imageUrl);
+
+  return (
+    <div className="rounded-lg bg-white flex items-center justify-center">
+      <article
+        className={`${outerHeightClass} ${outerWidthClass} shrink-0 relative flex items-center justify-center`}
+      >
+        <div className={`${innerHeightClass} ${innerWidthClass} relative`}>
+          <Image
+            priority
+            src={imgSrc}
+            alt="alcohol image"
+            fill
+            className="object-contain"
+            sizes="100px"
+            onError={() => setImgSrc(Fallback)}
+          />
+        </div>
+      </article>
+    </div>
+  );
+};
 
 export default AlcoholImage;

--- a/src/app/(primary)/_components/FlavorTag.tsx
+++ b/src/app/(primary)/_components/FlavorTag.tsx
@@ -8,11 +8,11 @@ interface Props {
 
 function FlavorTag({
   tagList,
-  styleClass = 'border-subCoral text-subCoral px-2 py-0.5 rounded-md text-12',
+  styleClass = 'border-subCoral text-subCoral px-[10px] py-[5px] rounded-md text-12',
 }: Props) {
   return (
-    <section className="mx-5 py-5 border-b border-mainGray/30 space-y-1">
-      <div className="text-13 text-mainDarkGray">FLAVOR TAG</div>
+    <section className="mx-5 py-[21px] border-b border-mainGray/30 space-y-[10px]">
+      <div className="text-12 text-mainDarkGray">FLAVOR TAG</div>
       <div className="flex flex-wrap gap-1">
         {tagList.map((tag) => (
           <div key={tag} className="overflow-hidden flex-shrink-0">

--- a/src/app/(primary)/_components/TimeLineItem.tsx
+++ b/src/app/(primary)/_components/TimeLineItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import {
@@ -9,6 +9,7 @@ import { formatDate } from '@/utils/formatDate';
 import { truncStr } from '@/utils/truncStr';
 import { TimeFormat } from '@/types/FormatDate';
 import { Rate } from '@/types/History';
+import Fallback from 'public/bottle.svg';
 
 interface BaseProps {
   date: string;
@@ -49,6 +50,7 @@ function TimeLineItem(props: Props) {
     content,
     redirectUrl,
   } = props as RatingProps & ReviewProps;
+  const [imgSrc, setImgSrc] = useState(imageSrc);
   const { getIcon, iconAlt, renderDescription, needsRate, needsDescription } =
     HISTORY_TYPE_INFO[type];
 
@@ -87,13 +89,14 @@ function TimeLineItem(props: Props) {
               </p>
               {renderDescription && renderDescription(getDescriptionProps())}
             </div>
-            {imageSrc && (
+            {imgSrc && (
               <Image
                 className="mr-1 rounded object-cover"
-                src={imageSrc}
+                src={imgSrc}
                 width={25}
                 height={34}
                 alt="alcoholImage"
+                onError={() => setImgSrc(Fallback)}
               />
             )}
           </div>

--- a/src/app/(primary)/history/_components/HistoryEmptyState.tsx
+++ b/src/app/(primary)/history/_components/HistoryEmptyState.tsx
@@ -4,29 +4,23 @@ import EmptyView from '@/app/(primary)/_components/EmptyView';
 interface HistoryEmptyStateProps {
   isLoading: boolean;
   error: unknown;
-  totalCount?: number;
 }
 
 export const HistoryEmptyState = ({
   isLoading,
   error,
-  totalCount = 0,
 }: HistoryEmptyStateProps) => {
   const getEmptyViewText = () => {
     if (isLoading) return '데이터를 가져오고 있어요:)';
     if (error) return '데이터를 가져오지 못 했어요..';
-    return '히스토리가 없어요!';
+    return '아직 히스토리가 없어요!';
   };
 
-  if (totalCount === 0 || error || isLoading) {
-    return (
-      <section className="w-full">
-        <article className="py-5 w-full border-y border-mainGray/30">
-          <EmptyView text={getEmptyViewText()} />
-        </article>
-      </section>
-    );
-  }
-
-  return null;
+  return (
+    <section className="w-full mt-3 mb-[26px]">
+      <article className="py-5 w-full border-y border-mainGray/30">
+        <EmptyView text={getEmptyViewText()} />
+      </article>
+    </section>
+  );
 };

--- a/src/app/(primary)/history/_components/Timeline.tsx
+++ b/src/app/(primary)/history/_components/Timeline.tsx
@@ -165,11 +165,7 @@ export default function Timeline({
       </List>
       <div ref={targetRef} />
       {(error || isLoading || !(data.userHistories?.length > 0)) && (
-        <HistoryEmptyState
-          isLoading={isLoading}
-          error={error}
-          totalCount={data.userHistories?.length}
-        />
+        <HistoryEmptyState isLoading={isLoading} error={error} />
       )}
     </section>
   );

--- a/src/app/(primary)/review/[id]/_components/Reply/ReplyInput.tsx
+++ b/src/app/(primary)/review/[id]/_components/Reply/ReplyInput.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect } from 'react';
 import { useFormContext, FieldValues, SubmitHandler } from 'react-hook-form';
 import { AuthService } from '@/lib/AuthService';
+import useModalStore from '@/store/modalStore';
 
 interface Props {
   textareaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
@@ -15,6 +16,7 @@ export default function ReplyInput({ textareaRef, handleCreateReply }: Props) {
   const content = watch('content');
   const mentionName = watch('replyToReplyUserName');
   const newTextareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const { handleLoginModal } = useModalStore();
 
   const handleResizeHeight = () => {
     if (newTextareaRef.current) {
@@ -75,6 +77,13 @@ export default function ReplyInput({ textareaRef, handleCreateReply }: Props) {
     newTextareaRef.current = textareaRef.current;
   }, [textareaRef]);
 
+  const handleTextareaClick = (e: React.MouseEvent<HTMLTextAreaElement>) => {
+    if (!isLogin) {
+      e.preventDefault();
+      handleLoginModal();
+    }
+  };
+
   return (
     <div className="fixed bottom-[6.7rem] left-0 right-0 mx-auto w-full max-w-2xl px-4 z-10">
       <div className="bg-[#f6f6f6] pt-1 px-3 rounded-lg shadow-md flex items-center">
@@ -86,7 +95,6 @@ export default function ReplyInput({ textareaRef, handleCreateReply }: Props) {
                 : '로그인 후 댓글을 작성할 수 있어요:)'
             }
             className="flex-grow p-1 text-mainGray text-13 bg-[#f6f6f6] resize-none max-h-[50px] overflow-hidden focus:outline-none"
-            disabled={!isLogin}
             onInput={handleInput}
             rows={1}
             ref={(e) => {
@@ -95,6 +103,7 @@ export default function ReplyInput({ textareaRef, handleCreateReply }: Props) {
             }}
             value={content}
             maxLength={300}
+            onClick={handleTextareaClick}
           />
         </div>
         <button

--- a/src/app/(primary)/review/_components/form/RatingForm.tsx
+++ b/src/app/(primary)/review/_components/form/RatingForm.tsx
@@ -14,7 +14,7 @@ export default function RatingForm() {
         이 술에 대한 평가를 남겨보세요.
       </p>
       <div>
-        <StarRating size={50} rate={watch('rating')} handleRate={handleRate} />
+        <StarRating size={42} rate={watch('rating')} handleRate={handleRate} />
       </div>
     </article>
   );

--- a/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
@@ -74,62 +74,64 @@ function Review({ data, onRefresh }: Props) {
 
   return (
     <>
-      <div className="space-y-2 border-b border-mainGray/30 pb-3 pt-3">
+      <div className="border-b border-mainGray/30 py-[15px]">
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-1">
+          <div className="flex items-center  space-x-2">
             <Link href={`/user/${data.userInfo.userId}`}>
               <div className="flex items-center space-x-1">
-                <div className="w-7 h-7 rounded-full overflow-hidden">
+                <div className="w-[22px] h-[22px] rounded-full overflow-hidden">
                   <Image
                     className="object-cover"
                     src={data.userInfo.userProfileImage || DEFAULT_USER_IMAGE}
                     alt="user_img"
-                    width={28}
-                    height={28}
+                    width={22}
+                    height={22}
                   />
                 </div>
-                <p className="text-mainGray text-12">
+                <p className="text-mainGray text-11">
                   {truncStr(data.userInfo.nickName, 12)}
                 </p>
               </div>
             </Link>
-            {data.isBestReview && (
-              <Label
-                name="베스트"
-                icon="/icon/thumbup-filled-white.svg"
-                styleClass="bg-mainCoral text-white px-2 py-[0.1rem] text-10 border-mainCoral rounded"
-              />
-            )}
-            {data.isMyReview && (
-              <Label
-                name="나의 코멘트"
-                icon="/icon/user-outlined-subcoral.svg"
-                iconHeight={10}
-                styleClass="border-mainCoral text-mainCoral px-2 py-[0.1rem] text-10 rounded"
-              />
-            )}
+            <div className="flex items-center space-x-1">
+              {data.isBestReview && (
+                <Label
+                  name="베스트"
+                  icon="/icon/thumbup-filled-white.svg"
+                  styleClass="bg-mainCoral text-white px-2 py-[0.1rem] text-10 border-mainCoral rounded"
+                />
+              )}
+              {data.isMyReview && (
+                <Label
+                  name="나의 코멘트"
+                  icon="/icon/user-outlined-subcoral.svg"
+                  iconHeight={10}
+                  styleClass="border-mainCoral text-mainCoral px-2 py-[0.1rem] text-10 rounded"
+                />
+              )}
+            </div>
           </div>
           {data.myRating && <Star rating={data.myRating} size={20} />}
         </div>
-        <div className="flex items-center space-x-1">
+        <div className="flex items-center space-x-1 mt-[10px]">
           <Image
             src={
               data.sizeType === 'BOTTLE'
                 ? '/bottle.svg'
                 : '/icon/glass-filled-subcoral.svg'
             }
-            width={12}
-            height={12}
+            width={14}
+            height={14}
             alt={data.sizeType === 'BOTTLE' ? 'Bottle Price' : 'Glass Price'}
           />
-          <p className="text-mainGray text-12 font-semibold">
+          <p className="text-mainGray text-12 font-bold">
             {data.sizeType === 'BOTTLE' ? '병 가격 ' : '잔 가격'}
           </p>
           <p className="text-mainGray text-12 font-normal">
             {data.price ? `${numberWithCommas(data.price)} ₩` : '-'}
           </p>
         </div>
-        <div className="grid grid-cols-5 space-x-2">
+        <div className="grid grid-cols-5 space-x-2 mt-[6px]">
           <p className="col-span-4 text-mainDarkGray text-12">
             <Link href={`/review/${data.reviewId}`}>
               {truncStr(data.reviewContent, 135)}
@@ -150,9 +152,9 @@ function Review({ data, onRefresh }: Props) {
             </div>
           )}
         </div>
-        <div className="flex justify-between text-11 text-mainGray">
+        <div className="flex justify-between text-11 text-mainGray mt-[10px]">
           <div className="flex space-x-3">
-            <div className="flex items-center space-x-1">
+            <div className="flex items-center space-x-[2px]">
               <LikeBtn
                 reviewId={data.reviewId}
                 isLiked={isLiked}
@@ -161,19 +163,19 @@ function Review({ data, onRefresh }: Props) {
                   setIsLiked(isLikedByMe);
                 }}
                 handleNotLogin={handleLoginModal}
-                size={10}
+                size={12}
               />
               <p>{data.likeCount}</p>
             </div>
-            <div className="flex items-center space-x-1">
+            <div className="flex items-center space-x-[2px]">
               <Image
                 src={
                   data.hasReplyByMe
                     ? '/icon/comment-filled-subcoral.svg'
                     : '/icon/comment-outlined-gray.svg'
                 }
-                width={10}
-                height={10}
+                width={12}
+                height={12}
                 alt="comment"
               />
               <p>{data.replyCount}</p>
@@ -188,7 +190,7 @@ function Review({ data, onRefresh }: Props) {
             )}
           </div>
           <div className="flex items-center">
-            <p className="text-10">{formatDate(data.createAt) as string}</p>
+            <p className="text-11">{formatDate(data.createAt) as string}</p>
             <button
               className="cursor-pointer"
               onClick={() => {

--- a/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
+++ b/src/app/(primary)/search/[category]/[id]/_components/Review.tsx
@@ -131,27 +131,27 @@ function Review({ data, onRefresh }: Props) {
             {data.price ? `${numberWithCommas(data.price)} ₩` : '-'}
           </p>
         </div>
-        <div className="grid grid-cols-5 space-x-2 mt-[6px]">
-          <p className="col-span-4 text-mainDarkGray text-12">
-            <Link href={`/review/${data.reviewId}`}>
+        <Link href={`/review/${data.reviewId}`}>
+          <div className="grid grid-cols-5 space-x-2 mt-[6px]">
+            <p className="col-span-4 text-mainDarkGray text-12">
               {truncStr(data.reviewContent, 135)}
               {data.reviewContent.length > 135 && (
                 <span className="text-mainGray">더보기</span>
               )}
-            </Link>
-          </p>
-          {data.reviewImageUrl && (
-            <div className="flex justify-end items-center">
-              <Image
-                className="w-[3.8rem] h-[3.8rem]"
-                src={data.reviewImageUrl}
-                alt="content_img"
-                width={60}
-                height={60}
-              />
-            </div>
-          )}
-        </div>
+            </p>
+            {data.reviewImageUrl && (
+              <div className="flex justify-end items-center">
+                <Image
+                  className="w-[3.8rem] h-[3.8rem]"
+                  src={data.reviewImageUrl}
+                  alt="content_img"
+                  width={60}
+                  height={60}
+                />
+              </div>
+            )}
+          </div>
+        </Link>
         <div className="flex justify-between text-11 text-mainGray mt-[10px]">
           <div className="flex space-x-3">
             <div className="flex items-center space-x-[2px]">

--- a/src/app/(primary)/search/[category]/[id]/layout.tsx
+++ b/src/app/(primary)/search/[category]/[id]/layout.tsx
@@ -5,5 +5,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <div>{children}</div>;
+  return <div className="min-h-screen relative">{children}</div>;
 }

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -51,11 +51,12 @@ function SearchAlcohol() {
         setData(result);
         setIsPicked(alcohols.isPicked);
         setAlcoholDetails([
-          { title: '카테고리', content: alcohols.engCategory || '-' },
-          { title: '국가/지역', content: alcohols.engRegion || '-' },
-          { title: '캐스크', content: alcohols.cask || '-' },
-          { title: '도수(%)', content: alcohols.abv || '-' },
-          { title: '증류소', content: alcohols.engDistillery || '-' },
+          { title: '증류소', content: alcohols.engDistillery },
+          {
+            title: '국가/지역',
+            content: alcohols.engRegion?.replace('/', '/\n') || '-',
+          },
+          { title: '도수', content: `${alcohols.abv}%` },
         ]);
       }
     } catch (error) {
@@ -195,7 +196,7 @@ function SearchAlcohol() {
               />
             </div>
             <div className="mb-5">
-              <article className="grid place-items-center space-y-2 py-5">
+              <article className="grid place-items-center space-y-2 pt-[25px] pb-[21px]">
                 {getRatingMessage(
                   data?.alcohols?.myAvgRating,
                   data?.alcohols?.myRating,
@@ -204,16 +205,30 @@ function SearchAlcohol() {
                   <StarRating rate={rate} size={42} handleRate={handleRate} />
                 </div>
               </article>
-              <section className="mx-5 py-5 border-y border-mainGray/30 grid grid-cols-2 gap-2">
-                {alcoholDetails.map((item: DetailItem) => (
-                  <div
-                    key={item.content}
-                    className="flex text-12 text-mainDarkGray items-start gap-2"
-                  >
-                    <div className="min-w-14 font-semibold">{item.title}</div>
-                    <div className="flex-1 font-normal">{item.content}</div>
+              <section className="mx-5 py-[21px] border-y border-mainGray/30">
+                <div className="grid gap-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    {alcoholDetails.map((item: DetailItem) => (
+                      <div
+                        key={item.content}
+                        className="flex text-12 text-mainDarkGray items-start gap-2"
+                      >
+                        <div className="min-w-14 font-semibold">
+                          {item.title}
+                        </div>
+                        <div className="flex-1 font-normal whitespace-pre-line">
+                          {item.content}
+                        </div>
+                      </div>
+                    ))}
                   </div>
-                ))}
+                  <div className="flex text-12 text-mainDarkGray items-start gap-2">
+                    <div className="min-w-14 font-semibold">캐스크</div>
+                    <div className="flex-1 font-normal break-words">
+                      {data?.alcohols?.cask || '-'}
+                    </div>
+                  </div>
+                </div>
               </section>
               {data?.alcohols?.alcoholsTastingTags && (
                 <FlavorTag tagList={data.alcohols.alcoholsTastingTags} />

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -272,8 +272,8 @@ function SearchAlcohol() {
             data.reviewInfo.totalCount !== 0 ? (
               <>
                 <div className="h-4 bg-sectionWhite" />
-                <section className="mx-5 py-5 space-y-3">
-                  <p className="text-13 text-mainGray font-normal">
+                <section className="mx-5 pt-[34px] pb-[20px]">
+                  <p className="text-11 text-mainGray font-normal mb-[10px]">
                     총 {data.reviewInfo.totalCount}개
                   </p>
                   <div className="border-b border-mainGray/30" />

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -118,7 +118,7 @@ function SearchAlcohol() {
               이에요.
             </p>
           </div>
-          <div>
+          <div className="text-10">
             <p>최근 평가한 별점은 {`${myRating}`}점이에요.</p>
             <p>다른 별점을 주시고 싶으시면 언제든지 변경해보세요!</p>
           </div>
@@ -195,13 +195,13 @@ function SearchAlcohol() {
               />
             </div>
             <div className="mb-5">
-              <article className="grid place-items-center space-y-3 py-5">
+              <article className="grid place-items-center space-y-2 py-5">
                 {getRatingMessage(
                   data?.alcohols?.myAvgRating,
                   data?.alcohols?.myRating,
                 )}
                 <div>
-                  <StarRating rate={rate} size={50} handleRate={handleRate} />
+                  <StarRating rate={rate} size={42} handleRate={handleRate} />
                 </div>
               </article>
               <section className="mx-5 py-5 border-y border-mainGray/30 grid grid-cols-2 gap-2">

--- a/src/app/(primary)/user/[id]/_components/Timeline.tsx
+++ b/src/app/(primary)/user/[id]/_components/Timeline.tsx
@@ -79,69 +79,77 @@ function Timeline() {
   return (
     <>
       <article>
-        <div>
+        <div className="mb-[26px]">
           <div className="font-semibold">
             <p className="text-15 text-subCoral">나의 보틀 여정 히스토리</p>
             <p className="text-10 text-brightGray">
               별점, 평가,찜하기 활동내역을 살펴볼 수 있어요.
             </p>
           </div>
-          <div className="border-t border-mainGray/30 my-3" />
-          <div className="relative w-[339px] mx-auto">
-            <div className="absolute left-[2.7rem] top-6 bottom-0 w-px border-l border-dashed border-subCoral z-0" />
-            <div className="relative z-10 pb-3">
-              {Object.entries(groupedHistory).map(
-                ([yearMonth, items], index) => (
-                  <div key={yearMonth} className="relative">
-                    <div className="pl-4 mb-5">
-                      <Label
-                        name={yearMonth}
-                        styleClass="border-white px-2.5 py-1 rounded-md text-11 bg-bgGray text-subCoral"
-                      />
-                    </div>
-                    <div className="z-10 space-y-5">
-                      {items.map((item: History, itemIndex) => {
-                        const prevItem =
-                          itemIndex > 0 ? items[itemIndex - 1] : null;
-                        const showDivider = shouldShowDivider(item, prevItem);
-                        return (
-                          <React.Fragment key={item.historyId}>
-                            {showDivider && (
-                              <div className="relative py-1">
-                                <div className="absolute left-0 right-0 h-px bg-bgGray" />
-                              </div>
-                            )}
-                            <TimeLineItem
-                              date={item.createdAt}
-                              alcoholName={item.alcoholName}
-                              imageSrc={item.imageUrl}
-                              type={item.eventType}
-                              rate={item.dynamicMessage}
-                              content={item.content}
-                              redirectUrl={item.redirectUrl}
-                            />
-                          </React.Fragment>
-                        );
-                      })}
-                    </div>
-                    {index !== Object.keys(groupedHistory).length - 1 && (
-                      <div className="my-5" />
-                    )}
-                  </div>
-                ),
-              )}
-            </div>
-
-            <div
-              className="absolute left-0 right-0 bottom-0 pointer-events-none z-10"
-              style={{
-                height: gradientHeight,
-                background:
-                  'linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%)',
-              }}
-            />
-          </div>
-          <div className="mb-2" />
+          {historyData?.[0]?.data.totalCount !== 0 && !error && !isLoading ? (
+            <>
+              <div className="border-t border-mainGray/30 my-3" />
+              <div className="relative w-[339px] mx-auto">
+                <div className="absolute left-[2.7rem] top-6 bottom-0 w-px border-l border-dashed border-subCoral z-0" />
+                <div className="relative z-10 pb-3">
+                  {Object.entries(groupedHistory).map(
+                    ([yearMonth, items], index) => (
+                      <div key={yearMonth} className="relative">
+                        <div className="pl-4 mb-5">
+                          <Label
+                            name={yearMonth}
+                            styleClass="border-white px-2.5 py-1 rounded-md text-11 bg-bgGray text-subCoral"
+                          />
+                        </div>
+                        <div className="z-10 space-y-5">
+                          {items.map((item: History, itemIndex) => {
+                            const prevItem =
+                              itemIndex > 0 ? items[itemIndex - 1] : null;
+                            const showDivider = shouldShowDivider(
+                              item,
+                              prevItem,
+                            );
+                            return (
+                              <React.Fragment key={item.historyId}>
+                                {showDivider && (
+                                  <div className="relative py-1">
+                                    <div className="absolute left-0 right-0 h-px bg-bgGray" />
+                                  </div>
+                                )}
+                                <TimeLineItem
+                                  date={item.createdAt}
+                                  alcoholName={item.alcoholName}
+                                  imageSrc={item.imageUrl}
+                                  type={item.eventType}
+                                  rate={item.dynamicMessage}
+                                  content={item.content}
+                                  redirectUrl={item.redirectUrl}
+                                />
+                              </React.Fragment>
+                            );
+                          })}
+                        </div>
+                        {index !== Object.keys(groupedHistory).length - 1 && (
+                          <div className="my-5" />
+                        )}
+                      </div>
+                    ),
+                  )}
+                </div>
+                <div
+                  className="absolute left-0 right-0 bottom-0 pointer-events-none z-10"
+                  style={{
+                    height: gradientHeight,
+                    background:
+                      'linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%)',
+                  }}
+                />
+              </div>
+              <div className="mb-2" />
+            </>
+          ) : (
+            <HistoryEmptyState isLoading={isLoading} error={error} />
+          )}
         </div>
         <LinkButton
           data={{
@@ -158,11 +166,6 @@ function Timeline() {
           }}
         />
       </article>
-      <HistoryEmptyState
-        isLoading={isLoading}
-        error={error}
-        totalCount={historyData?.[0]?.data.totalCount}
-      />
     </>
   );
 }

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -39,15 +39,15 @@ function LinkButton({
         <div className={imgSrc ? 'space-y-[90px]' : 'space-y-[11.7px]'}>
           <div className={`${icon && 'flex justify-between'} text-white`}>
             <div>
-              <p className="font-extrabold text-15">{korName}</p>
+              <p className="font-extrabold text-14">{korName}</p>
               <p className="text-12 font-normal">{engName}</p>
             </div>
             {icon && (
               <Image
                 src="/icon/arrow-right-white.svg"
                 alt="arrowIcon"
-                width={23}
-                height={23}
+                width={25}
+                height={25}
               />
             )}
           </div>

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -62,7 +62,12 @@ const ListItemRating = ({ data }: Props) => {
         </ItemLink>
 
         <article className="flex justify-between">
-          <StarRating rate={rate} handleRate={handleRate} />
+          <StarRating
+            rate={rate}
+            handleRate={handleRate}
+            outerHeightSize={36}
+            outerWidthSize={34}
+          />
           <div className="space-x-1.5 flex items-end">
             <PickBtn
               isPicked={isPicked}

--- a/src/components/StarRaiting.tsx
+++ b/src/components/StarRaiting.tsx
@@ -1,14 +1,26 @@
 import { useRef } from 'react';
 import Image from 'next/image';
 
-interface StarProps {
-  size: number;
-  index: number;
+interface Star {
+  size?: number;
+  outerHeightSize?: number;
+  outerWidthSize?: number;
   rate: number;
   handleRate: (rate: number) => void;
 }
 
-const Star = ({ size = 30, index, rate, handleRate }: StarProps) => {
+interface StarProps extends Star {
+  index: number;
+}
+
+const Star = ({
+  size = 30,
+  outerHeightSize = 54,
+  outerWidthSize = 52,
+  index,
+  rate,
+  handleRate,
+}: StarProps) => {
   const imageRef = useRef<HTMLImageElement>(null);
 
   // TODO: + 마우스 무브, 터치까지 대응되도록 수정
@@ -38,39 +50,47 @@ const Star = ({ size = 30, index, rate, handleRate }: StarProps) => {
   // FIXME: 별점 렌더링시 약간의 위치 움직임 있음
   return (
     <div
-      onClick={handleAction}
-      style={{ width: `${size}px`, height: `${size}px` }}
+      className="flex items-center justify-center"
+      style={{ width: `${outerWidthSize}px`, height: `${outerHeightSize}px` }}
     >
-      <Image
-        src={src}
-        width={size}
-        height={size}
-        alt="star"
-        ref={imageRef}
-        layout="responsive"
-      />
+      <div
+        className="relative"
+        style={{ width: `${size}px`, height: `${size}px` }}
+        onClick={handleAction}
+      >
+        <Image
+          src={src}
+          fill
+          alt="star"
+          ref={imageRef}
+          className="object-contain"
+          sizes={`${size}px`}
+        />
+      </div>
     </div>
   );
 };
 
-interface StarRatingProps {
-  size?: number;
-  rate: number;
-  handleRate: (rate: number) => void;
-}
-
-const StarRating = ({ size = 30, rate, handleRate }: StarRatingProps) => {
+const StarRating = ({
+  size = 30,
+  rate,
+  outerHeightSize,
+  outerWidthSize,
+  handleRate,
+}: Star) => {
   const maxRating = 10;
 
   return (
     <div className="relative w-full h-full">
-      <div className="flex space-x-1">
+      <div className="flex">
         {Array.from({ length: maxRating / 2 }, (_, i) => (
           <Star
             key={i}
             size={size}
             index={i + 1}
             rate={rate}
+            outerHeightSize={outerHeightSize}
+            outerWidthSize={outerWidthSize}
             handleRate={handleRate}
           />
         ))}

--- a/src/components/StarRaiting.tsx
+++ b/src/components/StarRaiting.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import Image from 'next/image';
 
-interface Star {
+interface BaseStar {
   size?: number;
   outerHeightSize?: number;
   outerWidthSize?: number;
@@ -9,7 +9,7 @@ interface Star {
   handleRate: (rate: number) => void;
 }
 
-interface StarProps extends Star {
+interface StarProps extends BaseStar {
   index: number;
 }
 
@@ -77,7 +77,7 @@ const StarRating = ({
   outerHeightSize,
   outerWidthSize,
   handleRate,
-}: Star) => {
+}: BaseStar) => {
   const maxRating = 10;
 
   return (


### PR DESCRIPTION
### PR 제목 (Title)

알콜 디테일 페이지 전체 스타일 수정 및 간단한 오류 수정
- [#354 ] 
- [#361 ]
- [#364 ] 
- [#374 ]

### 변경 사항 (Changes)
  - [x] 별 icon 별로 조금씩 사이즈가 다른 부분 수정
  - [x] 알콜 정보에 '케스크'가 길어지는 경우가 있어 위치 변경
  - [x] 전체적으로 피그마에 맞춰 스타일 수정
  - [x] 알콜 상세 페이지에 리뷰 리스트의 리뷰 상세로 가는 링크 영역 확대
  - [x] 로그인 전에 댓글 input 클릭시 로그인 모달 로직 추가
  - [x] 마이페이지 > 히스토리 없을 때 화면 피그마에 맞춰 레이아웃 수정
  - [x] 이미지 없을 경우, 대체 이미지 추가(알콜 상세, 히스토리 알콜 이미)  
