### PR TITLE
#377 아이폰 IOS 18.4 업데이트에 따른 링크 버그 수정

### DIFF
--- a/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
+++ b/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
@@ -221,7 +221,12 @@ function ReviewDetails({ data, handleLogin, textareaRef, onRefresh }: Props) {
                     <br />
                     {data.reviewInfo?.locationInfo?.mapUrl && (
                       <p className="text-subCoral m-0 p-0">
-                        <Link href={data.reviewInfo.locationInfo.mapUrl}>
+                        <Link
+                          href={data.reviewInfo.locationInfo.mapUrl}
+                          prefetch={false}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
                           지도보기
                         </Link>
                       </p>

--- a/src/app/(primary)/review/_components/form/AddressForm.tsx
+++ b/src/app/(primary)/review/_components/form/AddressForm.tsx
@@ -40,6 +40,7 @@ export default function AddressForm() {
         target="_blank"
         rel="noopener noreferrer"
         className="text-subCoral"
+        prefetch={false}
       >
         지도보기
       </Link>

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -17,6 +17,12 @@ interface Props {
   >;
 }
 
+const SearchButton = () => (
+  <div className="px-2 w-10 absolute top-0 right-1 h-full flex items-center justify-center">
+    <Image src={EnterIcon} alt="search button" />
+  </div>
+);
+
 export default function SearchBar({
   type = 'Search',
   handleSearch,
@@ -46,13 +52,8 @@ export default function SearchBar({
       type === 'Link' ? ' cursor-pointer' : ''
     }`,
     placeholder,
+    'aria-label': '검색어 입력',
   };
-
-  const SearchButton = () => (
-    <div className="px-2 w-10 absolute top-0 right-1 h-full flex items-center justify-center">
-      <Image src={EnterIcon} alt="search button" />
-    </div>
-  );
 
   useEffect(() => {
     setSearchText(currSearchKeyword ?? '');
@@ -95,6 +96,7 @@ export default function SearchBar({
           type="button"
           onMouseDown={handleDelete}
           className="absolute right-11 top-1/2 transform -translate-y-1/2 flex items-center justify-center"
+          aria-label="검색어 지우기"
         >
           <Image src={DeleteIcon} alt="delete" />
         </button>
@@ -102,6 +104,7 @@ export default function SearchBar({
       <button
         className="px-2 w-10 absolute top-0 right-1 h-full flex items-center justify-center"
         onMouseDown={handleSubmit}
+        aria-label="검색"
       >
         <SearchButton />
       </button>

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -21,7 +21,7 @@ export default function SearchBar({
   type = 'Search',
   handleSearch,
   handleFocus,
-  placeholder,
+  placeholder = '어떤 술을 찾고 계신가요?',
   setUpdateSearchText,
 }: Props) {
   const currSearchKeyword = useSearchParams().get('query');
@@ -34,19 +34,25 @@ export default function SearchBar({
     if (handleFocus) handleFocus(false);
   };
 
-  const handleOnFocus = () => {
-    if (handleFocus) handleFocus(true);
-  };
-
-  const handleOnBlur = () => {
-    if (handleFocus) handleFocus(false);
-  };
-
   const handleDelete = (e: React.MouseEvent) => {
     e.preventDefault();
     setSearchText('');
     if (handleFocus) handleFocus(true);
   };
+
+  const inputProps = {
+    type: 'text',
+    className: `w-full bg-white rounded-lg h-10 pl-4 pr-12 outline-none text-mainCoral placeholder-mainCoral text-15 border border-mainCoral${
+      type === 'Link' ? ' cursor-pointer' : ''
+    }`,
+    placeholder,
+  };
+
+  const SearchButton = () => (
+    <div className="px-2 w-10 absolute top-0 right-1 h-full flex items-center justify-center">
+      <Image src={EnterIcon} alt="search button" />
+    </div>
+  );
 
   useEffect(() => {
     setSearchText(currSearchKeyword ?? '');
@@ -59,64 +65,46 @@ export default function SearchBar({
           setSearchText(newText);
         }
       });
-
       return () => setUpdateSearchText(null);
     }
   }, [setUpdateSearchText, searchText, type]);
 
+  if (type === 'Link') {
+    return (
+      <div className="relative">
+        <Link href="/search" className="relative">
+          <input {...inputProps} readOnly />
+          <SearchButton />
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="relative">
-      {type === 'Link' ? (
-        <Link href="/search" className="relative">
-          <div className="w-full flex items-center bg-white rounded-lg h-10 pl-4 pr-12 hover:pointer">
-            <p className="absolute t-0 text-mainCoral text-15 font-medium">
-              {placeholder || '찾으시는 술이 있으신가요?'}
-            </p>
-            <div className="w-6 absolute right-3 hover:pointer">
-              <Image
-                src="/icon/search-subcoral.svg"
-                width={50}
-                height={50}
-                alt="search button"
-              />
-            </div>
-          </div>
-        </Link>
-      ) : (
-        <>
-          <input
-            type="text"
-            className="w-full bg-white rounded-lg h-10 pl-4 pr-12 outline-none text-mainCoral placeholder-mainCoral text-15 border border-mainCoral"
-            placeholder={placeholder || '어떤 술을 찾고 계신가요?'}
-            value={searchText}
-            onChange={(e) => {
-              setSearchText(e.target.value);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                handleSubmit();
-              }
-            }}
-            onFocus={handleOnFocus}
-            onBlur={handleOnBlur}
-          />
-          {searchText?.length > 0 && (
-            <button
-              type="button"
-              onMouseDown={handleDelete}
-              className="absolute right-11 top-1/2 transform -translate-y-1/2"
-            >
-              <Image src={DeleteIcon} alt="delete" />
-            </button>
-          )}
-          <button
-            className="px-2 w-10 absolute top-0 right-1 h-full"
-            onMouseDown={handleSubmit}
-          >
-            <Image src={EnterIcon} alt="search button" />
-          </button>
-        </>
+      <input
+        {...inputProps}
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+        onFocus={() => handleFocus?.(true)}
+        onBlur={() => handleFocus?.(false)}
+      />
+      {searchText?.length > 0 && (
+        <button
+          type="button"
+          onMouseDown={handleDelete}
+          className="absolute right-11 top-1/2 transform -translate-y-1/2 flex items-center justify-center"
+        >
+          <Image src={DeleteIcon} alt="delete" />
+        </button>
       )}
+      <button
+        className="px-2 w-10 absolute top-0 right-1 h-full flex items-center justify-center"
+        onMouseDown={handleSubmit}
+      >
+        <SearchButton />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
### PR 제목 (Title)

- [#377 ]

### 변경 사항 (Changes)
  - [x] SearchInput은 text 스타일에 영향이 없도록 진짜 input으로 변경
  - [x] 외부 링크로 연결하는 Link에 prefetch false 적용

### 변경 이유 (Reason for Changes)
아이폰 IOS가 18.4 업데이트 후 <Link> 태그로 감싸진 곳에 스타일 버그 및 클릭 이벤트가 아예 안먹는 버그가 있는 것으로 확인 했습니다. 

### 테스트 방법 (Test Procedure)

- 메인 페이지에서 검색 버튼 확인
- 리뷰 디테일 화면 또는 리뷰 작성 화면에서 '지도보기' 클릭

### 참고 사항 (Additional Information)

* Next.js의 <Link> 컴포넌트는 기본적으로 prefetch 기능을 활성화하여 페이지를 사전에 로드하는데 이 기능이 모바일 환경에서 터치 이벤트와 충돌하여 링크 이동이 방해한다는 이슈가 있어서 false 처리했습니다. IOS 18.4 업데이트에 따른 관련 이슈가 아직 해결 방법으로 올라온 건 없어서 이 방법이 안되면 route를 사용하는 방식으로 바꿔야할 것 같아요...!
