### PR TITLE
[#290] Image 컴포넌트 개발

### DIFF
--- a/src/app/(primary)/_components/AlcoholImage.tsx
+++ b/src/app/(primary)/_components/AlcoholImage.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
-import Fallback from 'public/bottle.svg';
+import BaseImage from '@/components/BaseImage';
 
 interface Props {
   imageUrl: string;
@@ -27,7 +26,6 @@ const AlcoholImage = ({
   rounded = 'rounded-lg',
   priority = true,
 }: Props) => {
-  const [imgSrc, setImgSrc] = useState(imageUrl);
   const [isLoading, setIsLoading] = useState(true);
 
   return (
@@ -40,14 +38,13 @@ const AlcoholImage = ({
       <div
         className={`relative ${innerHeightClass} ${innerWidthClass} flex items-center justify-center`}
       >
-        <Image
-          priority={priority}
-          src={imgSrc}
+        <BaseImage
+          src={imageUrl}
           alt="alcohol image"
+          priority={priority}
           fill
-          className={`object-contain ${blendMode} ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
+          className={`object-contain ${blendMode}`}
           sizes={`${innerWidthClass.replace('w-[', '').replace(']', '')}px`}
-          onError={() => setImgSrc(Fallback)}
           onLoad={() => setIsLoading(false)}
         />
       </div>

--- a/src/app/(primary)/_components/AlcoholImage.tsx
+++ b/src/app/(primary)/_components/AlcoholImage.tsx
@@ -10,34 +10,47 @@ interface Props {
   outerWidthClass?: string;
   innerHeightClass?: string;
   innerWidthClass?: string;
+  bgColor?: string;
+  blendMode?: string;
+  rounded?: string;
+  priority?: boolean;
 }
 
 const AlcoholImage = ({
   imageUrl,
-  outerHeightClass = 'h-[162px]',
-  outerWidthClass = 'w-[100px]',
-  innerHeightClass = 'w-[80px] ',
-  innerWidthClass = 'h-[140px]',
+  outerHeightClass = 'h-[171px]', // default height for the image of review
+  outerWidthClass = 'w-[99px]',
+  innerWidthClass = 'w-[70px]',
+  innerHeightClass = 'h-[141px]',
+  bgColor = 'bg-white',
+  blendMode = '',
+  rounded = 'rounded-lg',
+  priority = true,
 }: Props) => {
   const [imgSrc, setImgSrc] = useState(imageUrl);
+  const [isLoading, setIsLoading] = useState(true);
 
   return (
-    <div className="rounded-lg bg-white flex items-center justify-center">
-      <article
-        className={`${outerHeightClass} ${outerWidthClass} shrink-0 relative flex items-center justify-center`}
+    <div
+      className={`${rounded} ${bgColor} flex items-center justify-center ${outerHeightClass} ${outerWidthClass} shrink-0 relative`}
+    >
+      {isLoading && (
+        <div className="absolute inset-0 bg-gray-200 animate-pulse" />
+      )}
+      <div
+        className={`relative ${innerHeightClass} ${innerWidthClass} flex items-center justify-center`}
       >
-        <div className={`${innerHeightClass} ${innerWidthClass} relative`}>
-          <Image
-            priority
-            src={imgSrc}
-            alt="alcohol image"
-            fill
-            className="object-contain"
-            sizes="100px"
-            onError={() => setImgSrc(Fallback)}
-          />
-        </div>
-      </article>
+        <Image
+          priority={priority}
+          src={imgSrc}
+          alt="alcohol image"
+          fill
+          className={`object-contain ${blendMode} ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
+          sizes={`${innerWidthClass.replace('w-[', '').replace(']', '')}px`}
+          onError={() => setImgSrc(Fallback)}
+          onLoad={() => setIsLoading(false)}
+        />
+      </div>
     </div>
   );
 };

--- a/src/app/(primary)/_components/AlcoholImage.tsx
+++ b/src/app/(primary)/_components/AlcoholImage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import BaseImage from '@/components/BaseImage';
 
 interface Props {
@@ -26,15 +25,12 @@ const AlcoholImage = ({
   rounded = 'rounded-lg',
   priority = true,
 }: Props) => {
-  const [isLoading, setIsLoading] = useState(true);
+  const innerWidth = parseInt(innerWidthClass.match(/\d+/)?.[0] || '0', 10);
 
   return (
     <div
-      className={`${rounded} ${bgColor} flex items-center justify-center ${outerHeightClass} ${outerWidthClass} shrink-0 relative`}
+      className={`${rounded} ${bgColor} flex items-center justify-center ${outerHeightClass} ${outerWidthClass} shrink-0`}
     >
-      {isLoading && (
-        <div className="absolute inset-0 bg-gray-200 animate-pulse" />
-      )}
       <div
         className={`relative ${innerHeightClass} ${innerWidthClass} flex items-center justify-center`}
       >
@@ -42,10 +38,10 @@ const AlcoholImage = ({
           src={imageUrl}
           alt="alcohol image"
           priority={priority}
-          fill
           className={`object-contain ${blendMode}`}
-          sizes={`${innerWidthClass.replace('w-[', '').replace(']', '')}px`}
-          onLoad={() => setIsLoading(false)}
+          rounded={rounded}
+          sizes={`${innerWidth}px`}
+          fill
         />
       </div>
     </div>

--- a/src/app/(primary)/_components/PopularCard.tsx
+++ b/src/app/(primary)/_components/PopularCard.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 import Star from '@/components/Star';
 import { truncStr } from '@/utils/truncStr';
 import { AlcoholAPI } from '@/types/Alcohol';
+import AlcoholImage from './AlcoholImage';
 
 interface Props {
   data: AlcoholAPI & { path: string };
@@ -17,16 +17,16 @@ export default function PopularCard({ data }: Props) {
       <div className="w-[166px]">
         <div className="w-full border-t-[2px] border-subCoral">
           <div className="w-full h-[166px] bg-sectionWhite relative flex shrink-0 items-center justify-center">
-            <div className="w-[150px] h-[140px] relative bg-sectionWhite">
-              <Image
-                src={imageUrl}
-                alt="alcohol image"
-                fill
-                sizes="150px"
-                className="object-contain mix-blend-multiply"
-                priority
-              />
-            </div>
+            <AlcoholImage
+              imageUrl={imageUrl}
+              outerHeightClass="h-[166px]"
+              outerWidthClass="w-[166px]"
+              innerHeightClass="h-[140px]"
+              innerWidthClass="w-[150px]"
+              bgColor="bg-sectionWhite"
+              blendMode="mix-blend-multiply"
+              rounded="rounded-none"
+            />
           </div>
           <div className="px-3 py-[10px] space-y-[6px] border-y-[2px] border-subCoral bg-bgGray">
             <div className="text-15 h-[38px] font-extrabold whitespace-normal break-words text-mainDarkGray">

--- a/src/app/(primary)/_components/TimeLineItem.tsx
+++ b/src/app/(primary)/_components/TimeLineItem.tsx
@@ -94,6 +94,7 @@ function TimeLineItem(props: Props) {
               className="rounded object-cover"
               width={25}
               height={34}
+              fill
             />
           </div>
         </Link>

--- a/src/app/(primary)/_components/TimeLineItem.tsx
+++ b/src/app/(primary)/_components/TimeLineItem.tsx
@@ -1,15 +1,14 @@
-import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import {
   HISTORY_TYPE_INFO,
   DescriptionProps,
 } from '@/app/(primary)/history/_components/filter/HistoryDescription';
+import BaseImage from '@/components/BaseImage';
 import { formatDate } from '@/utils/formatDate';
 import { truncStr } from '@/utils/truncStr';
 import { TimeFormat } from '@/types/FormatDate';
 import { Rate } from '@/types/History';
-import Fallback from 'public/bottle.svg';
 
 interface BaseProps {
   date: string;
@@ -50,7 +49,6 @@ function TimeLineItem(props: Props) {
     content,
     redirectUrl,
   } = props as RatingProps & ReviewProps;
-  const [imgSrc, setImgSrc] = useState(imageSrc);
   const { getIcon, iconAlt, renderDescription, needsRate, needsDescription } =
     HISTORY_TYPE_INFO[type];
 
@@ -89,16 +87,14 @@ function TimeLineItem(props: Props) {
               </p>
               {renderDescription && renderDescription(getDescriptionProps())}
             </div>
-            {imgSrc && (
-              <Image
-                className="mr-1 rounded object-cover"
-                src={imgSrc}
-                width={25}
-                height={34}
-                alt="alcoholImage"
-                onError={() => setImgSrc(Fallback)}
-              />
-            )}
+            <BaseImage
+              src={imageSrc}
+              alt="alcohol image"
+              priority
+              className="rounded object-cover"
+              width={25}
+              height={34}
+            />
           </div>
         </Link>
       )}

--- a/src/app/(primary)/inquire/[id]/page.tsx
+++ b/src/app/(primary)/inquire/[id]/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter, useParams } from 'next/navigation';
 import { SubHeader } from '@/app/(primary)/_components/SubHeader';
+import BaseImage from '@/components/BaseImage';
 import { InquireApi } from '@/app/api/InquireApi';
 import { formatDate } from '@/utils/formatDate';
 import { InquireDetailsApi } from '@/types/Inquire';
@@ -72,10 +73,10 @@ export default function Inquire() {
               <div className="space-y-2">
                 {inquireDetails.imageUrlList.map((imgData) => (
                   <div className="relative w-full h-52" key={imgData.viewUrl}>
-                    <Image
+                    <BaseImage
                       src={imgData.viewUrl}
-                      alt="review_img"
-                      fill
+                      alt="Inquire image"
+                      priority
                       className="cover"
                     />
                   </div>

--- a/src/components/BaseImage.tsx
+++ b/src/components/BaseImage.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Fallback from 'public/bottle.svg';
+
+interface Props {
+  src: string;
+  alt: string;
+  className?: string;
+  priority?: boolean;
+  fill?: boolean;
+  sizes?: string;
+  onLoad?: () => void;
+  onError?: () => void;
+  width?: number;
+  height?: number;
+}
+
+const BaseImage = ({
+  src,
+  alt,
+  className = '',
+  priority = false,
+  fill = false,
+  sizes,
+  onLoad,
+  onError,
+  width,
+  height,
+}: Props) => {
+  const [imgSrc, setImgSrc] = useState(src);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const handleError = () => {
+    setImgSrc(Fallback);
+    onError?.();
+  };
+
+  const handleLoad = () => {
+    setIsLoading(false);
+    onLoad?.();
+  };
+
+  return (
+    <Image
+      priority={priority}
+      src={imgSrc}
+      alt={alt}
+      fill={fill}
+      width={width}
+      height={height}
+      className={`${className} ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
+      sizes={sizes}
+      onError={handleError}
+      onLoad={handleLoad}
+    />
+  );
+};
+
+export default BaseImage;

--- a/src/components/BaseImage.tsx
+++ b/src/components/BaseImage.tsx
@@ -15,6 +15,7 @@ interface Props {
   onError?: () => void;
   width?: number;
   height?: number;
+  rounded?: string;
 }
 
 const BaseImage = ({
@@ -28,6 +29,7 @@ const BaseImage = ({
   onError,
   width,
   height,
+  rounded = '',
 }: Props) => {
   const [imgSrc, setImgSrc] = useState(src);
   const [isLoading, setIsLoading] = useState(true);
@@ -43,18 +45,30 @@ const BaseImage = ({
   };
 
   return (
-    <Image
-      priority={priority}
-      src={imgSrc}
-      alt={alt}
-      fill={fill}
-      width={width}
-      height={height}
-      className={`${className} ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
-      sizes={sizes}
-      onError={handleError}
-      onLoad={handleLoad}
-    />
+    <div
+      className={`relative ${rounded}`}
+      style={{
+        width: width ? `${width}px` : '100%',
+        height: height ? `${height}px` : '100%',
+        overflow: 'hidden',
+      }}
+    >
+      {isLoading && (
+        <div className="absolute inset-0 bg-gray-200 animate-pulse" />
+      )}
+      <Image
+        priority={priority}
+        src={imgSrc}
+        alt={alt}
+        fill={fill}
+        width={fill ? undefined : width}
+        height={fill ? undefined : height}
+        className={`${className} ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
+        sizes={sizes}
+        onError={handleError}
+        onLoad={handleLoad}
+      />
+    </div>
   );
 };
 

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -6,7 +6,7 @@ import PickBtn from '@/app/(primary)/_components/PickBtn';
 import { addNewLine } from '@/utils/addNewLine';
 import { AlcoholAPI } from '@/types/Alcohol';
 import useModalStore from '@/store/modalStore';
-import ItemImage from './_components/ItemImage';
+import AlcoholImage from '@/app/(primary)/_components/AlcoholImage';
 import ItemInfo from './_components/ItemInfo';
 import RatingCountIcon from 'public/icon/ratingcount-black.svg';
 import HasReviewIcon from 'public/icon/edit-filled-subcoral.svg';
@@ -39,7 +39,14 @@ const ListItem = ({ data }: Props) => {
           href={`/search/all/${alcoholId}`}
           className="flex justify-start items-center h-full"
         >
-          <ItemImage src={imageUrl} alt="위스키 이미지" />
+          <AlcoholImage
+            imageUrl={imageUrl}
+            outerHeightClass="h-[89px]"
+            outerWidthClass="w-[89px]"
+            innerHeightClass="h-[85px]"
+            innerWidthClass="w-[85px]"
+            rounded="rounded-none"
+          />
           <ItemInfo
             korName={addNewLine(korName)}
             engName={engName}

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -6,7 +6,7 @@ import PickBtn from '@/app/(primary)/_components/PickBtn';
 import { addNewLine } from '@/utils/addNewLine';
 import { AlcoholAPI } from '@/types/Alcohol';
 import useModalStore from '@/store/modalStore';
-import AlcoholImage from '@/app/(primary)/_components/AlcoholImage';
+import ItemImage from './_components/ItemImage';
 import ItemInfo from './_components/ItemInfo';
 import RatingCountIcon from 'public/icon/ratingcount-black.svg';
 import HasReviewIcon from 'public/icon/edit-filled-subcoral.svg';
@@ -39,14 +39,7 @@ const ListItem = ({ data }: Props) => {
           href={`/search/all/${alcoholId}`}
           className="flex justify-start items-center h-full"
         >
-          <AlcoholImage
-            imageUrl={imageUrl}
-            outerHeightClass="h-[89px]"
-            outerWidthClass="w-[89px]"
-            innerHeightClass="h-[85px]"
-            innerWidthClass="w-[85px]"
-            rounded="rounded-none"
-          />
+          <ItemImage src={imageUrl} alt="image" />
           <ItemInfo
             korName={addNewLine(korName)}
             engName={engName}

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -4,11 +4,11 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { RateAPI } from '@/types/Rate';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
+import AlcoholImage from '@/app/(primary)/_components/AlcoholImage';
 import { RateApi } from '@/app/api/RateApi';
 import useModalStore from '@/store/modalStore';
 import { AuthService } from '@/lib/AuthService';
 import ItemInfo from './_components/ItemInfo';
-import ItemImage from './_components/ItemImage';
 import StarRating from '../StarRaiting';
 
 interface Props {
@@ -49,7 +49,14 @@ const ListItemRating = ({ data }: Props) => {
   return (
     <article className="flex items-center space-x-2 text-mainBlack border-brightGray border-b h-[90px]">
       <ItemLink alcoholId={alcoholId}>
-        <ItemImage src={imageUrl} alt="위스키 이미지" />
+        <AlcoholImage
+          imageUrl={imageUrl}
+          outerHeightClass="h-[89px]"
+          outerWidthClass="w-[89px]"
+          innerHeightClass="h-[85px]"
+          innerWidthClass="w-[85px]"
+          rounded="rounded-none"
+        />
       </ItemLink>
 
       <section className="flex-1 space-y-1">

--- a/src/components/List/ListItemRating.tsx
+++ b/src/components/List/ListItemRating.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { RateAPI } from '@/types/Rate';
 import PickBtn from '@/app/(primary)/_components/PickBtn';
-import AlcoholImage from '@/app/(primary)/_components/AlcoholImage';
 import { RateApi } from '@/app/api/RateApi';
 import useModalStore from '@/store/modalStore';
 import { AuthService } from '@/lib/AuthService';
+import ItemImage from './_components/ItemImage';
 import ItemInfo from './_components/ItemInfo';
 import StarRating from '../StarRaiting';
 
@@ -49,14 +49,7 @@ const ListItemRating = ({ data }: Props) => {
   return (
     <article className="flex items-center space-x-2 text-mainBlack border-brightGray border-b h-[90px]">
       <ItemLink alcoholId={alcoholId}>
-        <AlcoholImage
-          imageUrl={imageUrl}
-          outerHeightClass="h-[89px]"
-          outerWidthClass="w-[89px]"
-          innerHeightClass="h-[85px]"
-          innerWidthClass="w-[85px]"
-          rounded="rounded-none"
-        />
+        <ItemImage src={imageUrl} alt="image" />
       </ItemLink>
 
       <section className="flex-1 space-y-1">

--- a/src/components/List/_components/ItemImage.tsx
+++ b/src/components/List/_components/ItemImage.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import Image from 'next/image';
-import Fallback from 'public/bottle.svg';
+import BaseImage from '@/components/BaseImage';
 
 interface Props {
   src: string;
@@ -10,19 +8,16 @@ interface Props {
 }
 
 const ItemImage = ({ src, alt }: Props) => {
-  const [imgSrc, setImgSrc] = useState(src);
-
   return (
     <div className="w-[89px] h-[89px] flex shrink-0 p-2 justify-center items-center">
       <div className="w-full h-full relative">
-        <Image
-          src={imgSrc}
+        <BaseImage
+          src={src}
           alt={alt}
+          priority
+          className="object-contain w-auto h-auto"
           fill
           sizes="85px"
-          className="object-contain w-auto h-auto"
-          priority
-          onError={() => setImgSrc(Fallback)}
         />
       </div>
     </div>


### PR DESCRIPTION
### PR 제목 (Title)
- #290 

### 변경 사항 (Changes)
  - [x] error, loading 로직이 들어간 BaseImage 컴포넌트 생성
  - [x] BaseImage 컴포넌트를 이용한 AlcoholImage, ItemImage 컴포넌트 리팩토링
  - [x] 일부 기본 Image 태그를 BaseImage 컴포넌트로 변경

### 테스트 방법 (Test Procedure)
현재 알콜 이미지를 불러오는 곳은 모두 BaseImage  또는 AlcoholImage 컴포넌트로 변경했습니다.

### 참고 사항 (Additional Information)
*Loading 스타일은 추후에 스켈레톤으로 변경되야해서 임시로 효과 적용했습니다.
*AlcoholImage랑 ItemImage을 하나로 합치고 싶었는데 묘하게 달라서 일단은 그대로 뒀습니다.
*api로 이미지를 받아오는 곳에만 해당 컴포넌트를 적용하려고 하는데 생각보다 많아서 서로 수정하는 코드에 보이면 변경하는 식으로 해야할 것 같아요.
*제가 생각한 방식으로만 만들어봐서 추가나 수정했으면 하는 부분이 있으면 코멘트 남겨주세요!
