### PR TITLE
[#303] 이용약관 외부 링크 핸들링 방식 변경 & 앱 플랫폼 감지 핸들러 추가

### DIFF
--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -31,7 +31,7 @@ export default function Login() {
     handleAppleLogin,
   } = useLogin();
   const { isLogin } = AuthService;
-  const { setIsInApp, setPlatform } = DeviceService;
+  const { setIsInApp, setPlatform, platform } = DeviceService;
   const { register, handleSubmit } = useForm<FormValues>();
 
   const handleSignup = () => {
@@ -127,7 +127,7 @@ export default function Login() {
 
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={handleKakaoLogin} />
-            {window?.platform === 'ios' && (
+            {platform === 'ios' && (
               <SocialLoginBtn type="APPLE" onClick={handleAppleLogin} />
             )}
           </article>

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -127,7 +127,7 @@ export default function Login() {
 
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={handleKakaoLogin} />
-            {window.platform === 'ios' && (
+            {window?.platform === 'ios' && (
               <SocialLoginBtn type="APPLE" onClick={handleAppleLogin} />
             )}
           </article>

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -127,7 +127,9 @@ export default function Login() {
 
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={handleKakaoLogin} />
-            <SocialLoginBtn type="APPLE" onClick={handleAppleLogin} />
+            {window.platform === 'ios' && (
+              <SocialLoginBtn type="APPLE" onClick={handleAppleLogin} />
+            )}
           </article>
         </section>
 

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
@@ -31,8 +31,10 @@ export default function Login() {
     handleAppleLogin,
   } = useLogin();
   const { isLogin } = AuthService;
-  const { setIsInApp, setPlatform, platform } = DeviceService;
+  const { setIsInApp } = DeviceService;
   const { register, handleSubmit } = useForm<FormValues>();
+
+  const [curPlatform, setCurPlatform] = useState('');
 
   const handleSignup = () => {
     router.push('/signup');
@@ -51,7 +53,7 @@ export default function Login() {
     if (window.isInApp) {
       handleWebViewMessage('deviceToken');
       setIsInApp(window.isInApp);
-      setPlatform(window.platform);
+      setCurPlatform(window.platform);
     }
   }, []);
 
@@ -127,7 +129,7 @@ export default function Login() {
 
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={handleKakaoLogin} />
-            {platform === 'ios' && (
+            {curPlatform === 'ios' && (
               <SocialLoginBtn type="APPLE" onClick={handleAppleLogin} />
             )}
           </article>

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -31,8 +31,7 @@ export default function Login() {
     handleAppleLogin,
   } = useLogin();
   const { isLogin } = AuthService;
-  const { setIsInApp } = DeviceService;
-
+  const { setIsInApp, setPlatform } = DeviceService;
   const { register, handleSubmit } = useForm<FormValues>();
 
   const handleSignup = () => {
@@ -47,11 +46,12 @@ export default function Login() {
     handleSendDeviceInfo();
   }, [isLogin]);
 
-  // NOTE: 인앱 상태일 때 웹뷰에 device token 발급 요청
+  // 인앱 환경에서 초기화
   useEffect(() => {
     if (window.isInApp) {
       handleWebViewMessage('deviceToken');
       setIsInApp(window.isInApp);
+      setPlatform(window.platform);
     }
   }, []);
 

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -54,10 +54,6 @@ export default function Login() {
   }, []);
 
   useEffect(() => {
-    console.log('DeviceService.platform', DeviceService.platform);
-  }, [DeviceService.platform]);
-
-  useEffect(() => {
     handleInitKakaoSdkLogin();
   }, []);
 

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -53,9 +53,12 @@ export default function Login() {
     if (window.isInApp) {
       handleWebViewMessage('deviceToken');
       setIsInApp(window.isInApp);
+    }
+
+    if (window.platform) {
       setCurPlatform(window.platform);
     }
-  }, []);
+  }, [window.isInApp, window.platform]);
 
   useEffect(() => {
     handleInitKakaoSdkLogin();

--- a/src/app/(custom)/login/page.tsx
+++ b/src/app/(custom)/login/page.tsx
@@ -31,10 +31,7 @@ export default function Login() {
     handleAppleLogin,
   } = useLogin();
   const { isLogin } = AuthService;
-  const { setIsInApp } = DeviceService;
   const { register, handleSubmit } = useForm<FormValues>();
-
-  const [curPlatform, setCurPlatform] = useState('');
 
   const handleSignup = () => {
     router.push('/signup');
@@ -52,13 +49,13 @@ export default function Login() {
   useEffect(() => {
     if (window.isInApp) {
       handleWebViewMessage('deviceToken');
-      setIsInApp(window.isInApp);
+      DeviceService.setIsInApp(window.isInApp);
     }
+  }, []);
 
-    if (window.platform) {
-      setCurPlatform(window.platform);
-    }
-  }, [window.isInApp, window.platform]);
+  useEffect(() => {
+    console.log('DeviceService.platform', DeviceService.platform);
+  }, [DeviceService.platform]);
 
   useEffect(() => {
     handleInitKakaoSdkLogin();
@@ -132,7 +129,7 @@ export default function Login() {
 
           <article className="flex flex-col gap-2">
             <SocialLoginBtn type="KAKAO" onClick={handleKakaoLogin} />
-            {curPlatform === 'ios' && (
+            {DeviceService.platform === 'ios' && (
               <SocialLoginBtn type="APPLE" onClick={handleAppleLogin} />
             )}
           </article>

--- a/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
+++ b/src/app/(primary)/user/[id]/_components/SidebarHeader.tsx
@@ -119,21 +119,13 @@ const SidebarHeader = () => {
       },
       {
         text: '이용약관',
-        action: () =>
-          window.open(
-            'https://bottle-note.notion.site/info?pvs=4',
-            '_blank',
-            'noopener,noreferrer',
-          ),
+        link: 'https://bottle-note.notion.site/info?pvs=4',
+        action: null,
       },
       {
         text: '개인정보 처리 방침',
-        action: () =>
-          window.open(
-            'http://bottle-note.notion.site/',
-            '_blank',
-            'noopener,noreferrer',
-          ),
+        link: 'http://bottle-note.notion.site/',
+        action: null,
       },
       {
         text: '로그아웃',
@@ -180,13 +172,27 @@ const SidebarHeader = () => {
                   animate="visible"
                   custom={index}
                 >
-                  <button
-                    onClick={menu.action}
-                    className="w-full flex justify-between"
-                  >
-                    <span>{menu.text}</span>
-                    <span>{'>'}</span>
-                  </button>
+                  {menu.action && (
+                    <button
+                      onClick={menu.action}
+                      className="w-full flex justify-between"
+                    >
+                      <span>{menu.text}</span>
+                      <span>{'>'}</span>
+                    </button>
+                  )}
+
+                  {menu.link && (
+                    <Link
+                      href={menu.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="w-full flex justify-between"
+                    >
+                      <span>{menu.text}</span>
+                      <span>{'>'}</span>
+                    </Link>
+                  )}
                 </motion.li>
               ))}
             </ul>

--- a/src/hooks/useWebViewInit.ts
+++ b/src/hooks/useWebViewInit.ts
@@ -4,6 +4,7 @@ import {
   getDeviceToken,
   handleWebViewMessage,
   sendLogToFlutter,
+  checkPlatform,
 } from '@/utils/flutterUtil';
 import { useAppSocialLogin } from './useAppSocialLogin';
 
@@ -29,6 +30,7 @@ export const useWebViewInit = () => {
 
     window.getDeviceToken = getDeviceToken;
     window.checkIsInApp = checkIsInApp;
+    window.checkPlatform = checkPlatform;
     window.sendLogToFlutter = sendLogToFlutter;
     window.onKakaoLoginSuccess = onKakaoLoginSuccess;
     window.onKakaoLoginError = onKakaoLoginError;
@@ -37,6 +39,7 @@ export const useWebViewInit = () => {
 
     if (isMobile) {
       handleWebViewMessage('checkIsInApp');
+      handleWebViewMessage('checkPlatform');
     }
   };
 

--- a/src/lib/DeviceService.ts
+++ b/src/lib/DeviceService.ts
@@ -5,6 +5,8 @@ export class DeviceService {
 
   static deviceToken: string | null = Storage.getItem('deviceToken');
 
+  static platform: string | null = Storage.getItem('platform');
+
   static setIsInApp(status: boolean) {
     Storage.setItem('isInApp', status);
     DeviceService.isInApp = status;
@@ -13,5 +15,10 @@ export class DeviceService {
   static setDeviceToken(token: string) {
     Storage.setItem('deviceToken', token);
     DeviceService.deviceToken = token;
+  }
+
+  static setPlatform(platform: string) {
+    Storage.setItem('platform', platform);
+    DeviceService.platform = platform;
   }
 }

--- a/src/lib/DeviceService.ts
+++ b/src/lib/DeviceService.ts
@@ -5,8 +5,6 @@ export class DeviceService {
 
   static deviceToken: string | null = Storage.getItem('deviceToken');
 
-  static platform: string | null = Storage.getItem('platform');
-
   static setIsInApp(status: boolean) {
     Storage.setItem('isInApp', status);
     DeviceService.isInApp = status;
@@ -15,10 +13,5 @@ export class DeviceService {
   static setDeviceToken(token: string) {
     Storage.setItem('deviceToken', token);
     DeviceService.deviceToken = token;
-  }
-
-  static setPlatform(platform: string) {
-    Storage.setItem('platform', platform);
-    DeviceService.platform = platform;
   }
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -13,6 +13,7 @@ declare global {
       platform: string,
     ) => { deviceToken: string; platform: string };
     checkIsInApp: (status: string) => boolean;
+    checkPlatform: (platform:string) => string;
     openAlbum:(imageDataBase64: string) => void; 
     sendLogToFlutter: (log: string) => void;
     onKakaoLoginSuccess:(email: string) => Promise<void>;

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -15,6 +15,7 @@ export function checkPlatform(platform: string) {
 
 export function getDeviceToken(token: string, platform: string) {
   DeviceService.setDeviceToken(token);
+  DeviceService.setPlatform(platform);
 
   return { deviceToken: token, platform };
 }

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -3,17 +3,18 @@ import { DeviceService } from '@/lib/DeviceService';
 export function checkIsInApp(status: string) {
   const result = status === 'false' ? false : Boolean(status);
   window.isInApp = result;
+
   return result;
 }
 
 export function checkPlatform(platform: string) {
   window.platform = platform;
+
   return platform;
 }
 
 export function getDeviceToken(token: string, platform: string) {
   DeviceService.setDeviceToken(token);
-  DeviceService.setPlatform(platform);
 
   return { deviceToken: token, platform };
 }

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -6,6 +6,11 @@ export function checkIsInApp(status: string) {
   return result;
 }
 
+export function checkPlatform(platform: string) {
+  window.platform = platform;
+  return platform;
+}
+
 export function getDeviceToken(token: string, platform: string) {
   DeviceService.setDeviceToken(token);
   DeviceService.setPlatform(platform);
@@ -16,6 +21,7 @@ export function getDeviceToken(token: string, platform: string) {
 export function handleWebViewMessage(
   message:
     | 'checkIsInApp'
+    | 'checkPlatform'
     | 'deviceToken'
     | 'logToFlutter'
     | 'openAlbum'

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -3,19 +3,20 @@ import { DeviceService } from '@/lib/DeviceService';
 export function checkIsInApp(status: string) {
   const result = status === 'false' ? false : Boolean(status);
   window.isInApp = result;
+  DeviceService.setIsInApp(result);
 
   return result;
 }
 
 export function checkPlatform(platform: string) {
   window.platform = platform;
+  DeviceService.setPlatform(platform);
 
   return platform;
 }
 
 export function getDeviceToken(token: string, platform: string) {
   DeviceService.setDeviceToken(token);
-  DeviceService.setPlatform(platform);
 
   return { deviceToken: token, platform };
 }


### PR DESCRIPTION
### PR 제목 (Title)

*[#303] 이용약관 외부 링크 핸들링 방식 변경

### 변경 사항 (Changes)

- [x] 사이드바 이용 약관쪽 window.open 대신 a 태그로 수정 
- [x] DeviceService.platform 핸들러 추가
- [x] ios 환경에서만 애플 로그인 활성화 되도록 변경 

### 변경 이유 (Reason for Changes)

- flutter 에서 사용하는 url_launcher 가 a 태그 의 target = _blank 만 감지가 되네요.
- 애플 소셜로그인은 ios 에서만 노출되는 것으로 변경했어요.

### 테스트 방법 (Test Procedure)

- 추후 사름님 pc 에 플러터 세팅해서 테스트 가능하도록 실행 매뉴얼 전달드릴게요.

### 참고 사항 (Additional Information)

* 혹 다른 기능에서 외부 링크로 핸들링 해야 할 일 있으면 a 태그를 활용하면 될 것 같아요.
