### PR TITLE
[#418] 책갈피 디자인 개선 및 '최근에 본 위스키' 화면 변경

### DIFF
--- a/src/app/(primary)/_components/AlcoholCard.tsx
+++ b/src/app/(primary)/_components/AlcoholCard.tsx
@@ -27,13 +27,13 @@ export default function AlcoholCard({ data }: Props) {
             rounded="rounded-none"
           />
         </div>
-        <div className="px-3 py-[10px] space-y-[6px] bg-bgGray">
+        <div className="px-2 py-[10px] space-y-[6px] bg-bgGray">
           <div className="text-13 h-[38px] font-extrabold whitespace-normal break-words text-mainDarkGray">
             {korName && truncStr(korName, 20)}
           </div>
           <div className="flex items-end justify-between text-subCoral">
             <Star rating={rating} size={15} />
-            <p className="text-11 font-bold leading-none">
+            <p className="text-11 font-bold leading-none tracking-tight">
               {(engCategory || '').toUpperCase()}
             </p>
           </div>

--- a/src/app/(primary)/_components/PopularList.tsx
+++ b/src/app/(primary)/_components/PopularList.tsx
@@ -73,24 +73,22 @@ function PopularList({ type = 'week' }: Props) {
   const { popularList, isLoading } = usePopularList({ type });
   const { isLogin } = AuthService;
 
-  if (isLoading) {
-    return <CardListContainer>로딩중...</CardListContainer>;
-  }
-
-  if (type === 'recent' && !isLogin) {
+  if ((type === 'recent' && !isLogin) || isLoading) {
     return (
       <CardListContainer>
-        <Description type={type} />
-        <div className="flex flex-col items-center justify-center">
-          <Image
-            src="/icon/logo-subcoral.svg"
-            alt="logo"
-            width={30}
-            height={30}
-          />
-          <p className="text-mainGray text-15 mt-5">
-            로그인 후 이용 가능한 서비스 입니다
-          </p>
+        <div className="flex flex-col h-full">
+          <Description type={type} />
+          <div className="flex flex-col items-center justify-center flex-grow">
+            <Image
+              src="/icon/logo-subcoral.svg"
+              alt="logo"
+              width={30}
+              height={30}
+            />
+            <p className="text-mainGray text-15 mt-5">
+              {isLoading ? '로딩중...' : '로그인 후 이용 가능한 서비스 입니다'}
+            </p>
+          </div>
         </div>
       </CardListContainer>
     );

--- a/src/app/(primary)/_components/PopularList.tsx
+++ b/src/app/(primary)/_components/PopularList.tsx
@@ -65,17 +65,21 @@ const Description = ({ type }: { type: ListType }) => {
   }
 };
 
+const CardListContainer = ({ children }: { children: React.ReactNode }) => {
+  return <div className="h-[321px]">{children}</div>;
+};
+
 function PopularList({ type = 'week' }: Props) {
   const { popularList, isLoading } = usePopularList({ type });
   const { isLogin } = AuthService;
 
   if (isLoading) {
-    return <div className="pt-[34px] pl-[25px]">로딩중...</div>;
+    return <CardListContainer>로딩중...</CardListContainer>;
   }
 
   if (type === 'recent' && !isLogin) {
     return (
-      <div className="pt-[34px] pl-[25px]">
+      <CardListContainer>
         <Description type={type} />
         <div className="flex flex-col items-center justify-center">
           <Image
@@ -85,15 +89,15 @@ function PopularList({ type = 'week' }: Props) {
             height={30}
           />
           <p className="text-mainGray text-15 mt-5">
-            로그인 후 확인 가능한 서비스 입니다
+            로그인 후 이용 가능한 서비스 입니다
           </p>
         </div>
-      </div>
+      </CardListContainer>
     );
   }
 
   return (
-    <div className="pt-[34px] pl-[25px]">
+    <CardListContainer>
       <Description type={type} />
       {popularList.length !== 0 ? (
         <div className="whitespace-nowrap overflow-x-auto overflow-y-hidden flex space-x-2 scrollbar-hide">
@@ -111,7 +115,7 @@ function PopularList({ type = 'week' }: Props) {
       ) : (
         <EmptyState type={type} />
       )}
-    </div>
+    </CardListContainer>
   );
 }
 

--- a/src/app/(primary)/_components/PopularList.tsx
+++ b/src/app/(primary)/_components/PopularList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import AlcoholCard from '@/app/(primary)/_components/AlcoholCard';
 import { usePopularList } from '@/hooks/usePopularList';
 import { AuthService } from '@/lib/AuthService';
@@ -70,6 +71,7 @@ const CardListContainer = ({ children }: { children: React.ReactNode }) => {
 };
 
 function PopularList({ type = 'week' }: Props) {
+  const router = useRouter();
   const { popularList, isLoading } = usePopularList({ type });
   const { isLogin } = AuthService;
 
@@ -78,16 +80,24 @@ function PopularList({ type = 'week' }: Props) {
       <CardListContainer>
         <div className="flex flex-col h-full">
           <Description type={type} />
-          <div className="flex flex-col items-center justify-center flex-grow">
+          <div className="flex flex-col items-center justify-center flex-grow space-y-[14px]">
             <Image
               src="/icon/logo-subcoral.svg"
               alt="logo"
-              width={30}
-              height={30}
+              width={28}
+              height={48}
             />
-            <p className="text-mainGray text-15 mt-5">
-              {isLoading ? '로딩중...' : '로그인 후 이용 가능한 서비스 입니다'}
+            <p className="text-mainGray text-16">
+              {isLoading ? '로딩중...' : '로그인 후 확인 가능한 서비스 입니다.'}
             </p>
+            {type === 'recent' && !isLogin && (
+              <button
+                className="w-[237px] py-[8.5px] text-16 font-bold text-subCoral border border-subCoral rounded-[18px]"
+                onClick={() => router.push('/login')}
+              >
+                로그인 하러가기
+              </button>
+            )}
           </div>
         </div>
       </CardListContainer>

--- a/src/app/(primary)/page.tsx
+++ b/src/app/(primary)/page.tsx
@@ -76,9 +76,11 @@ export default function Home() {
               scrollContainerRef={firstMenuScrollContainerRef}
               registerTab={firstMenuRegisterTab}
             />
-            {renderTopContent()}
+            <div className="pt-[33px] pb-[59px] pl-[25px]">
+              {renderTopContent()}
+            </div>
           </article>
-          <article className="pt-[60px] space-y-[18px]">
+          <article className="space-y-[18px]">
             <Tab
               variant="bookmark"
               tabList={secondMenuList}

--- a/src/app/api/AlcholsApi.ts
+++ b/src/app/api/AlcholsApi.ts
@@ -55,6 +55,7 @@ export const AlcoholsApi = {
 
   async getHistory() {
     const response = await fetchWithAuth(`/bottle-api/history/view/alcohols`, {
+      requireAuth: false,
       cache: 'force-cache',
     });
 

--- a/src/components/Tab/variants/BookmarkTab.tsx
+++ b/src/components/Tab/variants/BookmarkTab.tsx
@@ -16,7 +16,6 @@ const TAB_HEIGHT = 32;
 
 const BORDER_COLOR = '#CFCFCF';
 const BORDER_WIDTH = 1.5;
-const ACTIVE_BOTTOM_COVER = 2;
 
 const BookmarkTab = <T extends { id: string; name: string }>({
   currentTab,
@@ -30,18 +29,6 @@ const BookmarkTab = <T extends { id: string; name: string }>({
   return (
     <div className="w-full bg-white">
       <div className="relative">
-        {/* 전체 하단 라인 */}
-        <div
-          className="absolute left-0 right-0"
-          style={{
-            bottom: 0,
-            height: `${BORDER_WIDTH}px`,
-            backgroundColor: BORDER_COLOR,
-            zIndex: 0,
-          }}
-        />
-
-        {/* 탭 컨테이너 */}
         <div
           ref={scrollContainerRef}
           className="relative flex overflow-x-auto scrollbar-hide w-full scroll-smooth"
@@ -77,7 +64,32 @@ const BookmarkTab = <T extends { id: string; name: string }>({
                     className="absolute inset-0"
                     preserveAspectRatio="none"
                   >
-                    {/* 테두리 경로 */}
+                    <defs>
+                      <clipPath id={`tab-clip-${tab.id}`}>
+                        <path
+                          d={`
+                            M0,${TAB_HEIGHT}
+                            L12,8
+                            Q14,2 22,2
+                            H${TAB_WIDTH - 22}
+                            Q${TAB_WIDTH - 14},2 ${TAB_WIDTH - 12},8
+                            L${TAB_WIDTH},${TAB_HEIGHT}
+                          `}
+                        />
+                      </clipPath>
+                    </defs>
+
+                    {/* 배경색 적용 */}
+                    <rect
+                      x="0"
+                      y="0"
+                      width={TAB_WIDTH}
+                      height={TAB_HEIGHT}
+                      fill={currentTab.id === tab.id ? '#FFF' : '#F7F7F7'}
+                      clipPath={`url(#tab-clip-${tab.id})`}
+                    />
+
+                    {/* 테두리 외곽선 - 하단 제외 */}
                     <path
                       d={`
                         M0,${TAB_HEIGHT}
@@ -87,33 +99,21 @@ const BookmarkTab = <T extends { id: string; name: string }>({
                         Q${TAB_WIDTH - 14},2 ${TAB_WIDTH - 12},8
                         L${TAB_WIDTH},${TAB_HEIGHT}
                       `}
-                      fill={currentTab.id === tab.id ? '#FFF' : '#F7F7F7'}
+                      fill="none"
                       stroke={BORDER_COLOR}
                       strokeWidth={BORDER_WIDTH}
                       strokeLinejoin="round"
                     />
-                    {/* 하단 border: 비활성 탭만 표시 */}
+
+                    {/* 하단 선 - 비활성 탭만 */}
                     {currentTab.id !== tab.id && (
                       <line
                         x1="0"
-                        y1={TAB_HEIGHT}
+                        y1={TAB_HEIGHT - BORDER_WIDTH / 2}
                         x2={TAB_WIDTH}
-                        y2={TAB_HEIGHT}
+                        y2={TAB_HEIGHT - BORDER_WIDTH / 2}
                         stroke={BORDER_COLOR}
                         strokeWidth={BORDER_WIDTH}
-                        strokeLinecap="butt"
-                      />
-                    )}
-                    {/* 활성 탭 하단 흰색 덮개 */}
-                    {currentTab.id === tab.id && (
-                      <line
-                        x1="0"
-                        y1={TAB_HEIGHT}
-                        x2={TAB_WIDTH}
-                        y2={TAB_HEIGHT}
-                        stroke="#FFF"
-                        strokeWidth={ACTIVE_BOTTOM_COVER}
-                        strokeLinecap="butt"
                       />
                     )}
                   </svg>
@@ -133,9 +133,22 @@ const BookmarkTab = <T extends { id: string; name: string }>({
           {/* 오른쪽 여백 하단 라인 */}
           <div
             className="flex-grow min-w-[20px]"
-            style={{ borderBottom: `${BORDER_WIDTH}px solid ${BORDER_COLOR}` }}
+            style={{
+              borderBottom: `${BORDER_WIDTH}px solid ${BORDER_COLOR}`,
+              marginTop: `${TAB_HEIGHT - BORDER_WIDTH}px`,
+            }}
           />
         </div>
+        {/* 전체 하단 라인 */}
+        <div
+          className="absolute left-0 right-0"
+          style={{
+            bottom: 0,
+            height: `${BORDER_WIDTH}px`,
+            backgroundColor: BORDER_COLOR,
+            zIndex: 0,
+          }}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
### PR 제목 (Title)

- [#418 ]

### 변경 사항 (Changes)
- [x] Tab 라인 자연스럽게 변경(현재 모바일 환경에서 끊어짐 보임)
- [x] Tab 하단 라인 굵기 통일되게 수정(현재 tab 하단 라인과 여백 하단 라인 굵기가 다름)
- [x] 최근에 본 위스키 기획에 맞춰 로그인 버튼으로 변경
- [x] 탭 이동 시, 전체 레이아웃이 바뀌지 않게 높이 고정 적용
- [x] 메인 화면의 AlcoholCard에 engCategory가 길어지면 별점과 겹침 현상으로 카드 padding과 자간 수정 

### 테스트 방법 (Test Procedure)

메인 화면에서 확인 가능.

### 참고 사항 (Additional Information)

* 스켈레톤을 별도 이슈로 진행 예정입니다.
