### PR TITLE
[#342] 히스토리 filter api 호출 개선

### DIFF
--- a/src/app/(primary)/history/_components/HistoryEmptyState.tsx
+++ b/src/app/(primary)/history/_components/HistoryEmptyState.tsx
@@ -3,16 +3,19 @@ import EmptyView from '@/app/(primary)/_components/EmptyView';
 
 interface HistoryEmptyStateProps {
   isLoading?: boolean;
+  isFiltering?: boolean;
   error: unknown;
 }
 
 export const HistoryEmptyState = ({
   isLoading,
+  isFiltering = false,
   error,
 }: HistoryEmptyStateProps) => {
   const getEmptyViewText = () => {
     if (isLoading) return '데이터를 가져오고 있어요:)';
     if (error) return '데이터를 가져오지 못 했어요..';
+    if (isFiltering) return '필터 검색 결과가 없어요!';
     return '아직 히스토리가 없어요!';
   };
 

--- a/src/app/(primary)/history/_components/Timeline.tsx
+++ b/src/app/(primary)/history/_components/Timeline.tsx
@@ -179,7 +179,11 @@ export default function Timeline({
           </List.Section>
         </List>
       ) : (
-        <HistoryEmptyState isLoading={isLoading} error={error} />
+        <HistoryEmptyState
+          isLoading={isLoading}
+          error={error}
+          isFiltering={data.totalCount !== 0 && data.userHistories.length === 0}
+        />
       )}
       <div ref={targetRef} />
     </section>

--- a/src/app/(primary)/history/page.tsx
+++ b/src/app/(primary)/history/page.tsx
@@ -88,8 +88,10 @@ export default function History() {
 
   const handleFilterChange = async () => {
     const newParams = getQueryParams().toString();
-    setCurrentParams(newParams);
-    await refetch();
+    if (newParams !== currentParams) {
+      setCurrentParams(newParams);
+      await refetch();
+    }
   };
 
   const handleClose = async () => {

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -62,13 +62,11 @@ export default function SearchBar({
   useEffect(() => {
     if (type === 'Search' && setUpdateSearchText) {
       setUpdateSearchText(() => (newText: string) => {
-        if (searchText === '') {
-          setSearchText(newText);
-        }
+        setSearchText(newText);
       });
       return () => setUpdateSearchText(null);
     }
-  }, [setUpdateSearchText, searchText, type]);
+  }, [setUpdateSearchText, type]);
 
   if (type === 'Link') {
     return (


### PR DESCRIPTION
### PR 제목 (Title)

- [#342 ]

### 변경 사항 (Changes)
  - [x] filter 값이 바뀔 경우에만 api 호출되도록 조건 추가
  - [x] filter 조건에 해당하는 값이 없을 때 화면 추가
  - [x] search bar 버그 수정

### 변경 이유 (Reason for Changes)
search bar 버그는 검색창에 keyword가 있는 상태에서 최근 검색 목록에 있는 값을 선택하면 filter는 잘 적용이 되는데 검색창 input에는 이전 keyword가 그대로 나와서 해당 부분 수정했습니다.

### 테스트 방법 (Test Procedure)
히스토리 페이지에서 확인 가능
