### PR TITLE
플러터 인터페이스 변경에 따른 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "setenv:local": "shx cp git.environment-variables/application/nextjs/.env.local .env.local",
-    "setenv:dev": "shx cp git.environment-variables/application/nextjs/.env.dev .env.development",
-    "setenv:prod": "shx cp git.environment-variables/application/nextjs/.env.prod .env.production",
+    "setenv:local": "git submodule update --remote && shx cp git.environment-variables/application/nextjs/.env.local .env.local",
+    "setenv:dev": "git submodule update --remote && shx cp git.environment-variables/application/nextjs/.env.dev .env.development",
+    "setenv:prod": "git submodule update --remote && shx cp git.environment-variables/application/nextjs/.env.prod .env.production",
     "dev": "pnpm run setenv:dev && cross-env npx env-cmd -f .env.development next dev",
     "dev:local": "pnpm run setenv:local && cross-env npx env-cmd -f .env.local next dev",
     "dev:prod": "pnpm run setenv:prod && cross-env npx env-cmd -f .env.production next dev",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { AuthService } from '@/lib/AuthService';
 import { checkTokenValidity } from '@/utils/checkTokenValidity';
 import useModalStore from '@/store/modalStore';
 import { ROUTES } from '@/constants/routes';
+import { handleWebViewMessage } from '@/utils/flutterUtil';
 import Modal from './Modal';
 
 export interface NavItem {
@@ -117,6 +118,9 @@ function Navbar({ maxWidth }: { maxWidth: string }) {
             <button
               className={`flex flex-col items-center space-y-1 ${isMounted && !isActive(menu.link) ? 'opacity-40' : ''}`}
               onClick={() => handleNavigation(menu)}
+              onTouchEnd={() =>
+                handleWebViewMessage('triggerHaptic', { type: 'light' })
+              }
             >
               <div className="flex flex-col items-center justify-center space-y-[2px]">
                 <Image

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -131,8 +131,8 @@ export const useLogin = () => {
   const handleInitKakaoSdkLogin = () => {
     const kakaoSDK = document.createElement('script');
     kakaoSDK.async = false;
-    kakaoSDK.src = `https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js`;
-    kakaoSDK.integrity = process.env.KAKAO_INTEGIRITY!;
+    kakaoSDK.src = `https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js`;
+    kakaoSDK.integrity = process.env.NEXT_PUBLIC_KAKAO_INTEGRITY_HASH!;
     kakaoSDK.crossOrigin = `anonymous`;
     document.head.appendChild(kakaoSDK);
 

--- a/src/hooks/useWebViewInit.ts
+++ b/src/hooks/useWebViewInit.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  checkIsInApp,
   getDeviceToken,
   handleWebViewMessage,
   sendLogToFlutter,
@@ -20,16 +19,17 @@ export const useWebViewInit = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const { userAgent } = navigator;
-    const mobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
-    setIsMobile(mobile);
+    if (window.isInApp) {
+      setIsMobile(window.isInApp);
+    } else {
+      setIsMobile(null);
+    }
   }, []);
 
   const initWebView = () => {
     if (typeof window === 'undefined') return;
 
     window.getDeviceToken = getDeviceToken;
-    window.checkIsInApp = checkIsInApp;
     window.checkPlatform = checkPlatform;
     window.sendLogToFlutter = sendLogToFlutter;
     window.onKakaoLoginSuccess = onKakaoLoginSuccess;
@@ -38,7 +38,6 @@ export const useWebViewInit = () => {
     window.onAppleLoginError = onAppleLoginError;
 
     if (isMobile) {
-      handleWebViewMessage('checkIsInApp');
       handleWebViewMessage('checkPlatform');
     }
   };

--- a/src/hooks/useWebViewInit.ts
+++ b/src/hooks/useWebViewInit.ts
@@ -19,7 +19,7 @@ export const useWebViewInit = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    if (window.isInApp) {
+    if (typeof window.isInApp !== 'undefined') {
       setIsMobile(window.isInApp);
     } else {
       setIsMobile(null);

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -3,10 +3,10 @@ declare global {
     kakao: any;
     Kakao: any;
     FlutterMessageQueue: {
-      postMessage: (payload: any) => any;
+      postMessage: (message: string, args?: any) => any;
     };
      LogToFlutter: {
-      postMessage: (payload: any) => any;
+      postMessage: (payload: string) => any;
     };
     getDeviceToken: (
       token: string,

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -13,17 +13,48 @@ export function getDeviceToken(token: string, platform: string) {
   return { deviceToken: token, platform };
 }
 
-export function handleWebViewMessage(
-  message:
-    | 'checkPlatform'
-    | 'deviceToken'
-    | 'logToFlutter'
-    | 'openAlbum'
-    | 'openCamera'
-    | 'loginWithKakao'
-    | 'loginWithApple',
+type WebViewMessageType = {
+  checkPlatform: {
+    message: 'checkPlatform';
+    args?: never;
+  };
+  deviceToken: {
+    message: 'deviceToken';
+    args?: never;
+  };
+  logToFlutter: {
+    message: 'logToFlutter';
+    args: { log: string };
+  };
+  openAlbum: {
+    message: 'openAlbum';
+    args?: never;
+  };
+  openCamera: {
+    message: 'openCamera';
+    args?: never;
+  };
+  loginWithKakao: {
+    message: 'loginWithKakao';
+    args?: never;
+  };
+  loginWithApple: {
+    message: 'loginWithApple';
+    args?: never;
+  };
+  triggerHaptic: {
+    message: 'triggerHaptic';
+    args?: { type: 'light' | 'medium' | 'heavy' };
+  };
+};
+
+type WebViewMessage = WebViewMessageType[keyof WebViewMessageType];
+
+export function handleWebViewMessage<T extends WebViewMessage['message']>(
+  message: T,
+  args?: WebViewMessageType[T]['args'],
 ) {
-  return window.FlutterMessageQueue.postMessage(message);
+  return window.FlutterMessageQueue.postMessage(message, args);
 }
 
 export function openAlbum(imgDataBase64: string): string {

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -44,7 +44,7 @@ type WebViewMessageType = {
   };
   triggerHaptic: {
     message: 'triggerHaptic';
-    args?: { type: 'light' | 'medium' | 'heavy' };
+    args?: { type: 'light' | 'medium' | 'heavy' | 'selection' | 'vibrate' };
   };
 };
 
@@ -54,7 +54,8 @@ export function handleWebViewMessage<T extends WebViewMessage['message']>(
   message: T,
   args?: WebViewMessageType[T]['args'],
 ) {
-  return window.FlutterMessageQueue.postMessage(message, args);
+  if (!window.isInApp) return;
+  window.FlutterMessageQueue.postMessage(message, args);
 }
 
 export function openAlbum(imgDataBase64: string): string {

--- a/src/utils/flutterUtil.ts
+++ b/src/utils/flutterUtil.ts
@@ -1,13 +1,5 @@
 import { DeviceService } from '@/lib/DeviceService';
 
-export function checkIsInApp(status: string) {
-  const result = status === 'false' ? false : Boolean(status);
-  window.isInApp = result;
-  DeviceService.setIsInApp(result);
-
-  return result;
-}
-
 export function checkPlatform(platform: string) {
   window.platform = platform;
   DeviceService.setPlatform(platform);
@@ -23,7 +15,6 @@ export function getDeviceToken(token: string, platform: string) {
 
 export function handleWebViewMessage(
   message:
-    | 'checkIsInApp'
     | 'checkPlatform'
     | 'deviceToken'
     | 'logToFlutter'


### PR DESCRIPTION
### PR 제목 (Title)

* 플러터 인터페이스 변경에 따른 업데이트

### 변경 사항 (Changes)

- [x] 웹뷰 여부를 판단하는 함수 대신 플러터에서 주입된 window.isInApp 값 참조하도록 수정
  - 플러터에서 값을 주입시켜버리면, 주입되지 않은 경우(웹 개발환경) 플러터에 핸들러 메시지를 보내지 않아 기존에 발생했던 에러가 사라지게 됩니다. 더 간단한 방식이어서 플러터쪽 업데이트하면서 변경했어요.
- [x] 카카오 웹 로그인의 integrity key 값 변경  
   - 버전과 맞지 않는 integrity 값이 있어서 변경했고, env 로 등록했으니 submodule 업데이트해서 적용하면 될 것 같아요. 
- [x] 햅틱 피드백 채널링 추가
  - Navbar 에 우선 적용. 더블 터치 및 터치시 UI적 피드백은 좀 더 개선이 필요할 것 같네요.

### 테스트 방법 (Test Procedure)

- 웹 개발환경에서 다시 모바일 디바이스 모드로 개발 가능.

### 참고 사항 (Additional Information)

* 지금 이슈가 이원화되어서 어디를 기준으로 브랜치를 발행해야될지 모르겠어요. 이제는 거의 앱 레파지토리 쪽에 등록된 이슈 위주로 돌아가는 것 같아서 그쪽 이슈 번호를 따라서 브랜치를 따는게 어떨까 생각중입니다. 괜히 두개로 나눈것같아서요..ㅋㅋ 의견주세요..
