### PR TITLE
fix: 위스키 검색 시 마지막 글자 중복 입력 버그 수정 

### DIFF
--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -44,6 +44,7 @@ export default function SearchBar({
 
   const handleDelete = (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     handleClear();
   };
 
@@ -78,7 +79,7 @@ export default function SearchBar({
       {searchText?.length > 0 && (
         <button
           type="button"
-          onMouseDown={handleDelete}
+          onClick={handleDelete}
           className="absolute right-14 top-1/2 transform -translate-y-1/2 flex items-center justify-center"
           aria-label="검색어 지우기"
         >
@@ -87,7 +88,7 @@ export default function SearchBar({
       )}
       <button
         className="px-2 w-10 absolute top-0 right-1 h-full flex items-center justify-center"
-        onMouseDown={handleSubmit}
+        onClick={handleSubmit}
         aria-label="검색"
       >
         <SearchButton />

--- a/src/hooks/useSearchInput.ts
+++ b/src/hooks/useSearchInput.ts
@@ -68,7 +68,7 @@ export const useSearchInput = ({
   // 키보드 이벤트 처리 (엔터 키로 검색 실행 + 포커스 아웃)
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
         e.preventDefault();
         handleSubmit();
       }


### PR DESCRIPTION
---
name: Pull Request Template
about: Template for creating a new Pull Request
title: ''
labels: ''
assignees: ''

---
### PR 제목 (Title)

  [Fix] 한글 검색 시 마지막 글자 중복 입력 버그 수정

  ### 변경 사항 (Changes)

  * IME composition 이벤트 처리를 추가하여 한글 입력 시 마지막 글자가 중복되는 문제 해결
  * 체크리스트
    - [x] `useSearchInput.ts:71` - 엔터키 이벤트에 `isComposing` 체크 추가
    - [x] `SearchBar.tsx:82, 91` - 버튼 클릭 이벤트를 `onMouseDown`에서 `onClick`으로 변경
    - [x] `SearchBar.tsx:47` - 삭제 버튼 핸들러에 `stopPropagation` 추가

  ### 변경 이유 (Reason for Changes)

  * 한글 입력 시 IME composition 중에 엔터를 누르거나 검색 버튼을 클릭하면, composition이 완료되기 전에 검색이 실행되어 마지막 글자가 중복 입력되는 버그 발생
  * 예시: "럼릭" 입력 후 검색 시 → "럼릭릭"으로 검색됨
  * IME를 사용하는 한글, 중국어, 일본어 등 모든 언어에서 발생하는 공통 이슈

  ### 테스트 방법 (Test Procedure)

  1. 검색창에 한글로 "럼릭" 입력
  2. 엔터키를 눌러 검색 실행 → "럼릭"으로 정확히 검색되는지 확인
  3. 검색창에 한글로 "위스키" 입력
  4. 검색 버튼 클릭 → "위스키"로 정확히 검색되는지 확인
  5. 검색어 입력 후 삭제 버튼 클릭 → 정상적으로 초기화되는지 확인

  ### 참고 사항 (Additional Information)

  * Related issue: #278 
  * `isComposing` 플래그는 브라우저 네이티브 이벤트 속성으로, IME composition 상태를 나타냄
  * `onClick` 사용 시 이벤트 순서: `mousedown` → `compositionend` → `blur` → `click`
