### PR TITLE
위스키 둘러보기 검색어 추가 버튼 정리

### DIFF
--- a/src/app/(primary)/explore/_components/ExploreSearchBar.tsx
+++ b/src/app/(primary)/explore/_components/ExploreSearchBar.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import Image from 'next/image';
-import { LucideSearch } from 'lucide-react';
 import SideFilterDrawer from '@/components/feature/SideFilterDrawer';
 import { Accordion } from '@/components/feature/SideFilterDrawer/Accordion';
 import { CATEGORY_MENUS_LIST } from '@/constants/common';
@@ -77,20 +76,14 @@ export const ExploreSearchBar = ({
 
         <div className="flex justify-end gap-[7px] absolute top-2.5 right-0">
           <button
-            className="label-default text-13 text-nowrap"
-            onClick={handleSubmit}
-          >
-            + 추가
-          </button>
-          <button
+            type="button"
             className="label-selected text-13 text-nowrap flex items-center gap-[2px]"
             onClick={handleSubmit}
           >
-            <LucideSearch className="w-3.5 h-3.5" />
-            검색
+            <span>+ 검색어 추가</span>
           </button>
           {isFilter && (
-            <button onClick={() => setIsOpenSideFilter(true)}>
+            <button type="button" onClick={() => setIsOpenSideFilter(true)}>
               <Image src={FilterIcon} alt="필터메뉴" />
             </button>
           )}


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- closes #206

## PR 타입 (Type of Change)

- [ ] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 리팩토링
- [x] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [x] 🔧 chore: 설정/빌드 변경
- [ ] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 위스키 둘러보기 검색어 입력 영역의 중복 `+ 추가` 버튼을 제거했습니다.
- 남은 버튼 문구를 `+ 검색어 추가`로 변경하고 돋보기 아이콘을 제거했습니다.
- `git.environment-variables` 서브모듈 포인터를 현재 워크스페이스 상태에 맞게 갱신했습니다.

## 변경 이유 (Reason for Changes)

- 동일한 검색어 추가 동작을 수행하는 진입점을 하나로 정리해 사용자 혼란을 줄입니다.

## 스크린샷 (Screenshots)

| Before | After |
|--------|-------|
|        |       |

## 테스트 방법 (Test Procedure)

1. `pnpm lint`
2. `pnpm prettier --check src/app/(primary)/explore/_components/ExploreSearchBar.tsx`

## 셀프 체크리스트 (Self Checklist)

- [ ] 로컬에서 정상 동작 확인
- [x] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [ ] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- `pnpm lint`는 통과하며, 기존 warning들은 남아 있습니다.