### PR TITLE
fix: align explore keyword chip icon

### DIFF
--- a/src/app/(primary)/explore/_components/ExploreKeywordChip.tsx
+++ b/src/app/(primary)/explore/_components/ExploreKeywordChip.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import type { SearchKeyword } from './ExploreSearchBar';
+import DeleteIcon from 'public/icon/reset-mainGray.svg';
+
+interface Props {
+  keyword: SearchKeyword;
+  onRemove: (keywordValue: string) => void;
+  textClassName?: string;
+}
+
+export const ExploreKeywordChip = ({
+  keyword,
+  onRemove,
+  textClassName = 'text-13',
+}: Props) => {
+  return (
+    <button
+      type="button"
+      className={`label-default inline-flex h-7 items-center gap-1 ${textClassName} leading-none`}
+      onClick={() => onRemove(keyword.value)}
+      aria-label={`${keyword.label} 검색어 지우기`}
+    >
+      <span className="leading-none">{keyword.label}</span>
+      <Image
+        src={DeleteIcon}
+        alt=""
+        aria-hidden
+        className="block h-3.5 w-3.5 shrink-0"
+      />
+    </button>
+  );
+};

--- a/src/app/(primary)/explore/_components/ReviewExploreList.tsx
+++ b/src/app/(primary)/explore/_components/ReviewExploreList.tsx
@@ -1,12 +1,10 @@
-import Image from 'next/image';
 import { usePaginatedQuery } from '@/queries/usePaginatedQuery';
 import { ExploreApi } from '@/api/explore/explore.api';
 import { ExploreReview } from '@/api/explore/types';
 import List from '@/components/feature/List/List';
-import Label from '@/components/ui/Display/Label';
 import ReviewCard from './ReviewListItem';
 import { ExploreSearchBar } from './ExploreSearchBar';
-import DeleteIcon from 'public/icon/reset-mainGray.svg';
+import { ExploreKeywordChip } from './ExploreKeywordChip';
 import { useExploreKeywords } from '../_hooks/useExploreKeywords';
 
 const REVIEW_TAB_ID = 'REVIEW_WHISKEY';
@@ -49,20 +47,10 @@ export const ReviewExplorerList = () => {
       <article className="flex gap-x-1 gap-y-1.5 flex-wrap">
         {keywords.map((keyword) => (
           <div key={keyword.value} className="overflow-hidden flex-shrink-0">
-            <Label
-              name={keyword.label}
-              styleClass="label-default text-12"
-              position="after"
-              icon={
-                <button
-                  type="button"
-                  onMouseDown={() => handleRemoveKeyword(keyword.value)}
-                  className=""
-                  aria-label="검색어 지우기"
-                >
-                  <Image src={DeleteIcon} alt="delete" />
-                </button>
-              }
+            <ExploreKeywordChip
+              keyword={keyword}
+              onRemove={handleRemoveKeyword}
+              textClassName="text-12"
             />
           </div>
         ))}

--- a/src/app/(primary)/explore/_components/WhiskeyExploreList.tsx
+++ b/src/app/(primary)/explore/_components/WhiskeyExploreList.tsx
@@ -1,12 +1,10 @@
-import Image from 'next/image';
 import { ExploreApi } from '@/api/explore/explore.api';
 import { ExploreAlcohol } from '@/api/explore/types';
 import { usePaginatedQuery } from '@/queries/usePaginatedQuery';
 import List from '@/components/feature/List/List';
-import Label from '@/components/ui/Display/Label';
 import WhiskeyListItem from './WhiskeyListItem';
 import { ExploreSearchBar } from './ExploreSearchBar';
-import DeleteIcon from 'public/icon/reset-mainGray.svg';
+import { ExploreKeywordChip } from './ExploreKeywordChip';
 import { useExploreKeywords } from '../_hooks/useExploreKeywords';
 import { useExploreFilters } from '../_hooks/useExploreFilters';
 
@@ -60,20 +58,9 @@ export const WhiskeyExplorerList = () => {
       <article className="flex gap-x-1 gap-y-1.5 flex-wrap border-b border-borderGray pb-6">
         {keywords.map((keyword) => (
           <div key={keyword.value} className="overflow-hidden flex-shrink-0">
-            <Label
-              name={keyword.label}
-              styleClass="label-default text-13"
-              position="after"
-              icon={
-                <button
-                  type="button"
-                  onMouseDown={() => handleRemoveKeyword(keyword.value)}
-                  className=""
-                  aria-label="검색어 지우기"
-                >
-                  <Image src={DeleteIcon} alt="delete" />
-                </button>
-              }
+            <ExploreKeywordChip
+              keyword={keyword}
+              onRemove={handleRemoveKeyword}
             />
           </div>
         ))}


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- closes bottle-note/workspace#208

## PR 타입 (Type of Change)

- [ ] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 리팩토링
- [x] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [ ] 🔧 chore: 설정/빌드 변경
- [ ] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 둘러보기 검색어 칩을 `ExploreKeywordChip` 컴포넌트로 분리했습니다.
- 검색어 텍스트와 삭제 아이콘을 단일 `inline-flex` 버튼 안에서 중앙 정렬하도록 변경했습니다.
- 리뷰/위스키 둘러보기 검색어 칩에서 중첩 button 구조를 제거했습니다.
- `git.environment-variables` 서브모듈 포인터가 갱신되었습니다.

## 변경 이유 (Reason for Changes)

- 검색어 태그 칩의 삭제 아이콘과 텍스트 수직 정렬 불일치를 수정하기 위해서입니다.

## 스크린샷 (Screenshots)

| Before | After |
|--------|-------|
|        |       |

## 테스트 방법 (Test Procedure)

1. `pnpm exec eslint 'src/app/(primary)/explore/_components/ExploreKeywordChip.tsx' 'src/app/(primary)/explore/_components/WhiskeyExploreList.tsx' 'src/app/(primary)/explore/_components/ReviewExploreList.tsx'`
2. `pnpm lint`
3. `pnpm exec tsc --noEmit`은 기존 `src/api/auth/auth.api.test.ts`의 Response mock 타입 오류로 실패합니다.

## 셀프 체크리스트 (Self Checklist)

- [ ] 로컬에서 정상 동작 확인
- [x] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [ ] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- `pnpm lint`는 통과했지만 기존 lint warning이 남아 있습니다.
