### PR TITLE
fix: 위스키 태그 행 가로 스크롤 적용

### DIFF
--- a/src/app/(primary)/explore/_components/WhiskeyListItem.tsx
+++ b/src/app/(primary)/explore/_components/WhiskeyListItem.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import { ROUTES } from '@/constants/routes';
 import { LABEL_NAMES } from '@/constants/common';
 import { ExploreAlcohol } from '@/types/Explore';
@@ -16,54 +14,10 @@ interface Props {
 }
 
 const WhiskeyListItem = ({ content, priority = false }: Props) => {
-  const sectionRef = useRef<HTMLElement>(null);
-  const [visibleTags, setVisibleTags] = useState<string[]>(
-    content.alcoholsTastingTags,
-  );
-
-  useEffect(() => {
-    const section = sectionRef.current;
-    if (!section) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible: string[] = [];
-
-        entries.forEach((entry) => {
-          const tag = entry.target.getAttribute('data-tag');
-          if (entry.isIntersecting && tag) {
-            visible.push(tag);
-          }
-        });
-
-        const orderedVisible = content.alcoholsTastingTags.filter((tag) =>
-          visible.includes(tag),
-        );
-
-        setVisibleTags(orderedVisible);
-      },
-      {
-        root: section,
-        rootMargin: '0px -10% 0px 0px',
-        threshold: 1.0,
-      },
-    );
-
-    setTimeout(() => {
-      const tagElements = section.querySelectorAll('[data-tag]');
-      tagElements.forEach((el) => observer.observe(el));
-    }, 0);
-
-    return () => observer.disconnect();
-  }, [content.alcoholsTastingTags]);
-
   return (
-    <section
-      ref={sectionRef}
-      className="flex items-center text-mainBlack py-6 w-full overflow-hidden"
-    >
+    <section className="flex items-center text-mainBlack py-6 w-full overflow-hidden">
       {/* image */}
-      <Link href={ROUTES.SEARCH.ALL(content.alcoholId)}>
+      <Link href={ROUTES.SEARCH.ALL(content.alcoholId)} className="shrink-0">
         <ItemImage
           src={content.alcoholUrlImg}
           alt="image"
@@ -75,9 +29,9 @@ const WhiskeyListItem = ({ content, priority = false }: Props) => {
       {/* info */}
       <Link
         href={ROUTES.SEARCH.ALL(content.alcoholId)}
-        className="flex flex-col items-start justify-center space-y-2"
+        className="flex min-w-0 flex-1 flex-col items-start justify-center space-y-2"
       >
-        <div className="space-y-2">
+        <div className="min-w-0 space-y-2">
           <ItemInfo
             korName={content.korName}
             engName={content.engName}
@@ -113,29 +67,15 @@ const WhiskeyListItem = ({ content, priority = false }: Props) => {
         </div>
 
         {/*  태그 */}
-        <div className="flex gap-x-1 w-full overflow-hidden">
-          {visibleTags?.map((tag) => (
-            <div
-              key={tag}
-              data-tag={tag}
-              className="overflow-hidden flex-shrink-0"
-            >
+        <div className="flex w-full min-w-0 gap-x-1 overflow-x-auto scrollbar-hide">
+          {content.alcoholsTastingTags?.map((tag) => (
+            <div key={tag} className="overflow-hidden flex-shrink-0">
               <Label
                 name={tag}
                 styleClass="label-default border-mainGray text-mainGray px-2 py-1 text-11"
               />
             </div>
           ))}
-          {visibleTags?.length < content.alcoholsTastingTags?.length && (
-            <div className="flex items-center pt-1.5">
-              <Image
-                src={'/icon/ellipsis-vertical-mainGray.svg'}
-                alt="ellipsis"
-                width={9}
-                height={2}
-              />
-            </div>
-          )}
         </div>
       </Link>
     </section>


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- closes bottle-note/workspace#216

## PR 타입 (Type of Change)

- [ ] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 리팩토링
- [x] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [x] 🔧 chore: 설정/빌드 변경
- [ ] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 위스키 둘러보기 카드의 테이스팅 태그 `IntersectionObserver` 필터링과 `...` 표시를 제거했습니다.
- 태그 행을 가로 스크롤/스와이프 가능한 UI로 변경해 모든 태그를 확인할 수 있게 했습니다.
- 카드 정보 영역이 남은 폭을 채우도록 `flex-1 min-w-0`을 적용하고, `git.environment-variables` submodule 포인터를 갱신했습니다.

## 변경 이유 (Reason for Changes)

- 일부 위스키에서 태그가 1개만 보이는 문제를 없애고, 태그 영역이 카드 폭을 안정적으로 사용하게 하기 위해서입니다.

## 스크린샷 (Screenshots)

| Before | After |
|--------|-------|
|        |       |

## 테스트 방법 (Test Procedure)

1. `pnpm exec jest --runInBand`
2. `pnpm exec eslint 'src/app/(primary)/explore/_components/WhiskeyListItem.tsx'`
3. `pnpm exec prettier --check 'src/app/(primary)/explore/_components/WhiskeyListItem.tsx'`

## 셀프 체크리스트 (Self Checklist)

- [ ] 로컬에서 정상 동작 확인
- [ ] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [ ] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- `pnpm exec tsc --noEmit --pretty false`는 기존 `src/api/auth/auth.api.test.ts:16`의 `Response` mock 타입 오류로 실패합니다.