### PR TITLE
feat: 타로 배너 닫힘 저장 및 메뉴 이벤트 추가

### DIFF
--- a/src/__tests__/components/SettingsMiniEventList.test.tsx
+++ b/src/__tests__/components/SettingsMiniEventList.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { SettingsMiniEventList } from '@/app/(primary)/settings/_components/SettingsMiniEventList';
+
+describe('SettingsMiniEventList', () => {
+  it('활성 이벤트만 4열 그리드에 렌더링하고 이름은 6자 초과 시 말줄임한다', () => {
+    render(
+      <SettingsMiniEventList
+        events={[
+          {
+            id: 'active-event',
+            name: '1234567',
+            thumbnailUrl: '/images/tarot/card-back.png',
+            targetUrl: '/active-event',
+            isActive: true,
+          },
+          {
+            id: 'inactive-event',
+            name: '비활성 이벤트',
+            thumbnailUrl: '/images/tarot/card-back.png',
+            targetUrl: '/inactive-event',
+            isActive: false,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('list')).toHaveClass('grid-cols-4');
+    expect(screen.getByRole('link', { name: '1234567' })).toHaveAttribute(
+      'href',
+      '/active-event',
+    );
+    expect(screen.getByText('123456...')).toBeInTheDocument();
+    expect(screen.queryByText('비활성 이벤트')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/TarotPromoCard.test.tsx
+++ b/src/__tests__/components/TarotPromoCard.test.tsx
@@ -1,0 +1,51 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  TarotPromoCard,
+  TAROT_PROMO_CLOSED_KEY,
+} from '@/components/feature/home/TarotPromoCard';
+
+describe('TarotPromoCard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('닫기 클릭 시 localStorage에 닫힘 값을 저장하고 배너를 숨긴다', () => {
+    render(<TarotPromoCard />);
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '닫기' }));
+
+    expect(localStorage.getItem(TAROT_PROMO_CLOSED_KEY)).toBe('true');
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(
+      screen.queryByText('위스키와 함께하는 타로점'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('localStorage에 닫힘 값이 있으면 배너를 렌더링하지 않는다', () => {
+    localStorage.setItem(TAROT_PROMO_CLOSED_KEY, 'true');
+
+    render(<TarotPromoCard />);
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(
+      screen.queryByText('위스키와 함께하는 타로점'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(primary)/settings/_components/SettingsMainScreen.tsx
+++ b/src/app/(primary)/settings/_components/SettingsMainScreen.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { MenuCategory } from '@/types/Settings';
+import { SettingsMiniEventList } from './SettingsMiniEventList';
 
 interface SettingsMainScreenProps {
   menuCategories: MenuCategory[];
@@ -30,6 +31,8 @@ export const SettingsMainScreen = ({
       initial="hidden"
       animate="visible"
     >
+      <SettingsMiniEventList />
+
       {menuCategories.map((category, categoryIndex) => (
         <div key={category.title}>
           {categoryIndex > 0 && <div className="border-t border-brightGray" />}

--- a/src/app/(primary)/settings/_components/SettingsMiniEventList.tsx
+++ b/src/app/(primary)/settings/_components/SettingsMiniEventList.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { ROUTES } from '@/constants/routes';
+
+const EVENT_NAME_MAX_LENGTH = 6;
+
+interface MiniEvent {
+  id: string;
+  name: string;
+  thumbnailUrl: string;
+  targetUrl: string;
+  isActive: boolean;
+}
+
+const MINI_EVENTS: MiniEvent[] = [
+  {
+    id: 'whiskey-tarot',
+    name: '위스키 타로',
+    thumbnailUrl: '/images/tarot/card-back.png',
+    targetUrl: ROUTES.WHISKEY_TAROT,
+    isActive: true,
+  },
+];
+
+export const truncateMiniEventName = (name: string) => {
+  if (name.length <= EVENT_NAME_MAX_LENGTH) return name;
+
+  return `${name.slice(0, EVENT_NAME_MAX_LENGTH)}...`;
+};
+
+interface SettingsMiniEventListProps {
+  events?: MiniEvent[];
+}
+
+export function SettingsMiniEventList({
+  events = MINI_EVENTS,
+}: SettingsMiniEventListProps) {
+  const activeEvents = events.filter((event) => event.isActive);
+
+  if (activeEvents.length === 0) return null;
+
+  return (
+    <section className="border-b border-brightGray py-[22px]">
+      <ul className="grid grid-cols-4 gap-x-3 gap-y-4">
+        {activeEvents.map((event) => (
+          <li key={event.id}>
+            <Link
+              href={event.targetUrl}
+              className="flex flex-col items-center gap-2"
+              aria-label={event.name}
+            >
+              <div className="relative h-14 w-14 overflow-hidden rounded-lg bg-brightGray">
+                <Image
+                  src={event.thumbnailUrl}
+                  alt=""
+                  fill
+                  sizes="64px"
+                  className="object-cover"
+                />
+              </div>
+              <span className="w-full text-center text-12 font-medium leading-none text-mainBlack">
+                {truncateMiniEventName(event.name)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/feature/home/TarotPromoCard.tsx
+++ b/src/components/feature/home/TarotPromoCard.tsx
@@ -2,16 +2,26 @@
 
 import { useRef, useState, useEffect } from 'react';
 import Link from 'next/link';
+import { Storage } from '@/lib/Storage';
+import { ROUTES } from '@/constants/routes';
+
+export const TAROT_PROMO_CLOSED_KEY = 'homeTarotPromoClosed';
 
 export function TarotPromoCard() {
-  const [show, setShow] = useState(true);
+  const [show, setShow] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const closeTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
+    if (Storage.getItem<boolean>(TAROT_PROMO_CLOSED_KEY)) {
+      return undefined;
+    }
+
+    setShow(true);
     const timer = setTimeout(() => {
       setIsVisible(true);
     }, 300);
+
     return () => {
       clearTimeout(timer);
       if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
@@ -21,6 +31,7 @@ export function TarotPromoCard() {
   const handleClose = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    Storage.setItem(TAROT_PROMO_CLOSED_KEY, true);
     setIsVisible(false);
     closeTimerRef.current = setTimeout(() => {
       setShow(false);
@@ -37,7 +48,7 @@ export function TarotPromoCard() {
       `}
     >
       <Link
-        href="/whiskey-tarot"
+        href={ROUTES.WHISKEY_TAROT}
         className="block p-4 bg-mainCoral/10 rounded-xl relative"
       >
         <button

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   HOME: '/',
   LOGIN: '/login',
   SIGNUP: '/signup',
+  WHISKEY_TAROT: '/whiskey-tarot',
   OAUTH: {
     KAKAO: '/oauth/kakao',
   },


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- closes bottle-note/workspace#183

## PR 타입 (Type of Change)

- [x] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 리팩토링
- [x] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [ ] 🔧 chore: 설정/빌드 변경
- [x] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 홈 타로 프로모션 배너 닫힘 상태를 localStorage에 저장해 재노출을 방지했습니다.
- 설정 메뉴 최상단에 활성 미니 이벤트 목록을 추가하고 위스키 타로 이벤트를 연결했습니다.
- 타로 경로 상수와 배너/미니 이벤트 테스트를 추가했습니다.

## 변경 이유 (Reason for Changes)

- 닫은 타로 배너가 계속 표시되는 문제를 해결하고, 메뉴 페이지 미니 이벤트 노출 요구사항을 반영하기 위함입니다.

## 스크린샷 (Screenshots)

| Before | After |
|--------|-------|
| 스크린샷 미첨부 | 스크린샷 미첨부 |

## 테스트 방법 (Test Procedure)

1. `pnpm lint`
2. `pnpm test -- TarotPromoCard SettingsMiniEventList --runInBand`

## 셀프 체크리스트 (Self Checklist)

- [x] 로컬에서 정상 동작 확인
- [x] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [x] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- `pnpm exec tsc --noEmit --pretty false`는 기존 `src/api/auth/auth.api.test.ts:16`의 Response 캐스팅 오류로 실패합니다.