### PR TITLE
Improve LCP image loading

### DIFF
--- a/src/app/(primary)/explore/_components/ReviewExploreList.tsx
+++ b/src/app/(primary)/explore/_components/ReviewExploreList.tsx
@@ -66,11 +66,15 @@ export const ReviewExplorerList = () => {
       >
         <List.Section className="space-y-[30px] divide-y-[1px]">
           {reviewList &&
-            [...reviewList].map((listData) =>
+            [...reviewList].map((listData, pageIndex) =>
               listData.data.items
                 .flat()
-                .map((review) => (
-                  <ReviewCard key={review.reviewId} content={review} />
+                .map((review, itemIndex) => (
+                  <ReviewCard
+                    key={review.reviewId}
+                    content={review}
+                    priority={pageIndex === 0 && itemIndex === 0}
+                  />
                 )),
             )}
           <div ref={targetRef} className="h-10" />

--- a/src/app/(primary)/explore/_components/ReviewListItem.tsx
+++ b/src/app/(primary)/explore/_components/ReviewListItem.tsx
@@ -20,9 +20,10 @@ import Label from '@/components/ui/Display/Label';
 
 interface Props {
   content: ExploreReview;
+  priority?: boolean;
 }
 
-const ReviewListItem = ({ content }: Props) => {
+const ReviewListItem = ({ content, priority = false }: Props) => {
   const { handleLoginModal } = useModalStore();
   const { isLoggedIn, user: userData } = useAuth();
   const [isLiked, setIsLiked] = useState(content.isLikedByMe);
@@ -87,7 +88,7 @@ const ReviewListItem = ({ content }: Props) => {
         {/* 리뷰 본문 */}
         <Link href={ROUTES.REVIEW.DETAIL(content.reviewId)}>
           <div className="flex flex-col gap-[14px]">
-            <ReviewImageCarousel images={productImages} />
+            <ReviewImageCarousel images={productImages} priority={priority} />
             <div
               className="text-15 text-mainDarkGray whitespace-pre-line break-words"
               dangerouslySetInnerHTML={{

--- a/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
+++ b/src/app/(primary)/review/[id]/_components/ReviewDetails.tsx
@@ -47,7 +47,7 @@ function ReviewDetails({
         <section className="mx-5 pb-5 border-b border-mainGray/30">
           {productImages?.length > 0 && (
             <div className="mb-[22px]">
-              <ReviewImageCarousel images={productImages} />
+              <ReviewImageCarousel images={productImages} priority />
             </div>
           )}
           <div

--- a/src/app/(primary)/review/[id]/page.tsx
+++ b/src/app/(primary)/review/[id]/page.tsx
@@ -185,18 +185,8 @@ export default function ReviewDetail() {
         <>
           <NavLayout>
             <div className="relative">
-              {alcoholInfo.imageUrl && (
-                <Image
-                  src={alcoholInfo.imageUrl}
-                  alt="배경 이미지"
-                  fill
-                  priority
-                  sizes="100vw"
-                  className="object-cover"
-                />
-              )}
               <div
-                className={`absolute inset-0 bg-mainCoral bg-opacity-90 ${isUnmounting ? 'hidden' : ''}`}
+                className={`absolute inset-0 bg-mainCoral ${isUnmounting ? 'hidden' : ''}`}
               />
               <div className="relative z-10">
                 <SubHeader bgColor="bg-none">

--- a/src/app/(primary)/search/[category]/[id]/page.tsx
+++ b/src/app/(primary)/search/[category]/[id]/page.tsx
@@ -239,19 +239,8 @@ export default function SearchAlcohol() {
         ) : (
           <>
             <div className="relative">
-              {/* 배경 레이어들 */}
-              {data?.alcohols?.alcoholUrlImg && (
-                <Image
-                  src={data.alcohols.alcoholUrlImg}
-                  alt=""
-                  fill
-                  priority
-                  sizes="100vw"
-                  className="object-cover"
-                />
-              )}
               <div
-                className={`absolute inset-0 bg-mainCoral bg-opacity-90 ${
+                className={`absolute inset-0 bg-mainCoral ${
                   isUnmounting ? 'hidden' : ''
                 }`}
               />

--- a/src/components/domain/review/ReviewImageCarousel.tsx
+++ b/src/components/domain/review/ReviewImageCarousel.tsx
@@ -32,7 +32,15 @@ export const convertImageUrlsToProductImageArray = (
 };
 
 // TODO: 이미지 여러장일 때 슬라이드 수정
-export const ReviewImageCarousel = ({ images }: { images: ProductImage[] }) => {
+interface ReviewImageCarouselProps {
+  images: ProductImage[];
+  priority?: boolean;
+}
+
+export const ReviewImageCarousel = ({
+  images,
+  priority = false,
+}: ReviewImageCarouselProps) => {
   const [api, setApi] = useState<CarouselApi>();
   const [current, setCurrent] = useState(0);
 
@@ -71,7 +79,7 @@ export const ReviewImageCarousel = ({ images }: { images: ProductImage[] }) => {
                 width={600}
                 height={600}
                 sizes="(max-width: 768px) 100vw, 600px"
-                priority={index === 0}
+                priority={priority && index === 0}
                 className="object-cover w-full h-full"
               />
             </div>

--- a/src/components/feature/home/HomeCarousel.tsx
+++ b/src/components/feature/home/HomeCarousel.tsx
@@ -66,10 +66,9 @@ function BannerImage({
         src={banner.imageUrl}
         alt={banner.name}
         fill
-        sizes="100vw"
+        sizes="(max-width: 430px) 100vw, 430px"
         priority={isPriority}
         quality={75}
-        unoptimized
         onLoad={() => setIsLoaded(true)}
         style={{ objectFit: 'cover' }}
         className="w-full h-full object-cover"


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- N/A

## PR 타입 (Type of Change)

- [ ] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [x] ♻️ refactor: 리팩토링
- [x] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [ ] 🔧 chore: 설정/빌드 변경
- [ ] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 홈 배너 이미지가 Next 이미지 최적화 경로를 타도록 `unoptimized`를 제거하고 실제 표시 폭 기준 `sizes`를 적용했습니다.
- 리뷰 이미지 캐러셀의 `priority`를 호출부에서 제어하도록 바꾸고, 탐색 첫 리뷰와 리뷰 상세 대표 이미지만 우선 로딩하도록 제한했습니다.
- 리뷰 상세와 위스키 상세 헤더의 장식용 100vw 배경 이미지 요청을 제거하고 CSS 배경색으로 대체했습니다.

## 변경 이유 (Reason for Changes)

- LCP 후보 이미지의 요청 크기와 우선 로딩 경쟁을 줄여 Core Web Vitals 지표를 개선하기 위해 변경했습니다.

## 테스트 방법 (Test Procedure)

1. `npm run lint`
2. `npm test -- --runInBand src/__tests__/components/HomeCarousel.test.tsx`
3. `npx tsc --noEmit`은 기존 `src/api/auth/auth.api.test.ts`의 `Response` mock 타입 오류로 실패함

## 셀프 체크리스트 (Self Checklist)

- [ ] 로컬에서 정상 동작 확인
- [x] `npm run lint` 통과
- [x] 불필요한 console.log 제거
- [ ] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- 별도 스크린샷은 첨부하지 않았습니다.