### PR TITLE
perf: improve infinite scroll trigger timing

### DIFF
--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -26,9 +26,9 @@ jobs:
           node-version: '22'
 
       - name: pnpm 설치
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9.15.9
           run_install: false
 
       - name: pnpm 캐시 활성화

--- a/.github/workflows/test_validation.yml
+++ b/.github/workflows/test_validation.yml
@@ -26,9 +26,9 @@ jobs:
           node-version: '22'
 
       - name: pnpm 설치
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9.15.9
           run_install: false
 
       - name: pnpm 캐시 활성화

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,29 +1,41 @@
-import { useEffect, useRef } from 'react';
-import { throttle } from '@/utils/throttle';
+import { useCallback, useEffect, useRef } from 'react';
 
-interface Options {
-  root?: Element | Document;
-  rootMargin?: string;
-  threshold?: number | number[];
-}
+const DEFAULT_THROTTLE_MS = 100;
 
 interface Props {
   fetchNextPage: () => void;
-  options?: Options;
+  options?: IntersectionObserverInit;
+  throttleMs?: number;
 }
 
-export const useInfiniteScroll = ({ fetchNextPage, options }: Props) => {
+export const useInfiniteScroll = ({
+  fetchNextPage,
+  options,
+  throttleMs = DEFAULT_THROTTLE_MS,
+}: Props) => {
   const targetRef = useRef<HTMLDivElement | null>(null);
   const fetchRef = useRef(fetchNextPage);
+  const lastTriggerTimeRef = useRef(0);
   fetchRef.current = fetchNextPage;
 
-  const observerCallback = useRef(
-    throttle((entries: IntersectionObserverEntry[]) => {
-      if (entries[0].isIntersecting) {
-        fetchRef.current();
+  const observerCallback = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      if (!entries[0]?.isIntersecting) return;
+
+      const now = Date.now();
+      const elapsedSinceLastTrigger = now - lastTriggerTimeRef.current;
+      const isWithinThrottleWindow =
+        throttleMs > 0 && elapsedSinceLastTrigger < throttleMs;
+
+      if (isWithinThrottleWindow) {
+        return;
       }
-    }),
-  ).current;
+
+      lastTriggerTimeRef.current = now;
+      fetchRef.current();
+    },
+    [throttleMs],
+  );
 
   useEffect(() => {
     const target = targetRef.current;

--- a/src/queries/usePaginatedQuery.ts
+++ b/src/queries/usePaginatedQuery.ts
@@ -2,6 +2,11 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { ApiResponse } from '@/api/_shared/types';
 
+const DEFAULT_INTERSECTION_OPTIONS: IntersectionObserverInit = {
+  rootMargin: '800px',
+  threshold: 0,
+};
+
 interface Props<T> {
   queryKey: [string, ...Array<any>];
   queryFn: (params: any) => Promise<ApiResponse<T>>;
@@ -10,6 +15,8 @@ interface Props<T> {
   enabled?: boolean;
   refetchOnMount?: boolean;
   gcTime?: number;
+  intersectionOptions?: IntersectionObserverInit;
+  intersectionThrottleMs?: number;
 }
 
 export const usePaginatedQuery = <T>({
@@ -20,6 +27,8 @@ export const usePaginatedQuery = <T>({
   refetchOnMount = true,
   staleTime = 0,
   gcTime = 1000 * 60 * 10,
+  intersectionOptions = DEFAULT_INTERSECTION_OPTIONS,
+  intersectionThrottleMs,
 }: Props<T>) => {
   const {
     data,
@@ -28,6 +37,7 @@ export const usePaginatedQuery = <T>({
     fetchNextPage,
     hasNextPage,
     isFetching,
+    isFetchingNextPage,
     refetch,
   } = useInfiniteQuery({
     queryKey,
@@ -49,14 +59,12 @@ export const usePaginatedQuery = <T>({
 
   const { targetRef } = useInfiniteScroll({
     fetchNextPage: () => {
-      if (!isFetching && hasNextPage) {
+      if (!isFetchingNextPage && hasNextPage) {
         fetchNextPage();
       }
     },
-    options: {
-      rootMargin: '300px',
-      threshold: 0,
-    },
+    options: intersectionOptions,
+    throttleMs: intersectionThrottleMs,
   });
 
   return {
@@ -64,6 +72,7 @@ export const usePaginatedQuery = <T>({
     error,
     isLoading,
     isFetching,
+    isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
     targetRef,


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- closes #226

## PR 타입 (Type of Change)

- [ ] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [x] ♻️ refactor: 리팩토링
- [ ] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [x] 🔧 chore: 설정/빌드 변경
- [ ] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 무한스크롤 observer 트리거를 trailing 없는 leading-only throttle 전략으로 변경했습니다.
- 다음 페이지 감지 기본 `rootMargin`을 `800px`로 확대하고, `isFetchingNextPage` 기준으로 중복 fetch를 막도록 개선했습니다.
- CI의 pnpm 버전을 lockfile v9와 호환되는 `9.15.9`로 업데이트했습니다.

## 변경 이유 (Reason for Changes)

- 리스트 끝에 닿기 전 다음 페이지 요청을 더 일찍 시작해 무한스크롤 체감 끊김을 줄이기 위해서입니다.
- 기존 trailing throttle이 빠른 observer 재감지에서 불필요한 후속 트리거를 만들 수 있어 fetch 트리거 전략을 명확히 분리했습니다.
- 기존 CI pnpm 8은 현재 `pnpm-lock.yaml`의 lockfile v9를 읽지 못해 install 단계에서 실패할 수 있었습니다.

## 테스트 방법 (Test Procedure)

1. `CI=true npx -y pnpm@9.15.9 install --frozen-lockfile`
2. `npx -y pnpm@9.15.9 exec eslint src/hooks/useInfiniteScroll.ts src/queries/usePaginatedQuery.ts`
3. `npx -y pnpm@9.15.9 build`
4. `npx -y pnpm@9.15.9 test -- --runInBand`
5. `git diff --check`

## 셀프 체크리스트 (Self Checklist)

- [x] 로컬에서 정상 동작 확인
- [ ] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [ ] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- `pnpm build`에서 sitemap dynamic usage 및 `useSearchParams()` deopt 경고가 출력되지만 build exit code는 0입니다.
- `pnpm test`는 `.next/standalone/package.json`로 인한 Jest haste-map 경고가 출력되지만 19 suites / 156 tests 모두 통과했습니다.
- https://github.com/bottle-note/workspace/issues/226
