### PR TITLE
큐레이션 검색 버튼 및 카드 문구 스타일 조정

### DIFF
--- a/src/app/(primary)/curation/_components/CurationCard.tsx
+++ b/src/app/(primary)/curation/_components/CurationCard.tsx
@@ -80,10 +80,10 @@ export function CurationCard({ curation, priority = false }: Props) {
           <span className="inline-flex rounded-full bg-white/30 px-2.5 py-1 text-12 font-bold text-white backdrop-blur-sm">
             {tagLabel}
           </span>
-          <h2 className="mt-4 line-clamp-2 text-20 font-extrabold text-white truncate">
+          <h2 className="mt-4 line-clamp-2 text-20 font-extrabold text-white">
             {curation.name}
           </h2>
-          <p className="mt-3.5 line-clamp-3 text-12 font-medium text-white truncate">
+          <p className="mt-3.5 line-clamp-5 text-12 font-medium text-white">
             {curation.description}
           </p>
         </div>

--- a/src/app/(primary)/curation/_components/CurationCard.tsx
+++ b/src/app/(primary)/curation/_components/CurationCard.tsx
@@ -83,7 +83,7 @@ export function CurationCard({ curation, priority = false }: Props) {
           <h2 className="mt-4 line-clamp-2 text-20 font-extrabold text-white">
             {curation.name}
           </h2>
-          <p className="mt-3.5 line-clamp-5 text-12 font-medium text-white">
+          <p className="mt-3.5 line-clamp-2 text-12 font-medium text-white">
             {curation.description}
           </p>
         </div>

--- a/src/app/(primary)/curation/_components/CurationCard.tsx
+++ b/src/app/(primary)/curation/_components/CurationCard.tsx
@@ -83,7 +83,7 @@ export function CurationCard({ curation, priority = false }: Props) {
           <h2 className="mt-4 line-clamp-2 text-20 font-extrabold text-white">
             {curation.name}
           </h2>
-          <p className="mt-3.5 line-clamp-3 text-12 font-light text-white">
+          <p className="mt-3.5 line-clamp-3 text-12 font-light leading-[18px] text-white">
             {curation.description}
           </p>
         </div>

--- a/src/app/(primary)/curation/_components/CurationCard.tsx
+++ b/src/app/(primary)/curation/_components/CurationCard.tsx
@@ -83,7 +83,7 @@ export function CurationCard({ curation, priority = false }: Props) {
           <h2 className="mt-4 line-clamp-2 text-20 font-extrabold text-white">
             {curation.name}
           </h2>
-          <p className="mt-3.5 line-clamp-2 text-12 font-medium text-white">
+          <p className="mt-3.5 line-clamp-3 text-12 font-light text-white">
             {curation.description}
           </p>
         </div>

--- a/src/app/(primary)/curation/page.tsx
+++ b/src/app/(primary)/curation/page.tsx
@@ -94,10 +94,10 @@ export default function CurationPage() {
             renderActions={({ submit }) => (
               <button
                 type="button"
-                className="label-selected inline-flex items-center gap-0.5 px-2.5 py-1 text-13 font-medium leading-none"
+                className="label-selected inline-flex h-7 items-center gap-1 text-13 font-medium leading-none"
                 onClick={submit}
               >
-                <Search size={12} aria-hidden />
+                <Search size={14} aria-hidden className="shrink-0" />
                 <span>검색</span>
               </button>
             )}


### PR DESCRIPTION
## Summary
- 큐레이션 검색 버튼을 기본 검색어 버튼 크기에 맞게 조정
- 큐레이션 카드 설명 텍스트를 3줄 clamp로 표시
- 카드 설명 텍스트 weight와 line-height 조정

## Test
- pnpm lint