### PR TITLE
fix: hide curation alcohol region and category tags

### DIFF
--- a/src/app/(primary)/curation/_components/TastingEventLineupItem.tsx
+++ b/src/app/(primary)/curation/_components/TastingEventLineupItem.tsx
@@ -17,15 +17,8 @@ export function TastingEventLineupItem({
   order,
 }: TastingEventLineupItemProps) {
   const { alcohol, stats, comment } = item;
-  const details = [
-    alcohol.abv && `도수 ${alcohol.abv}%`,
-    alcohol.korCategory,
-  ].filter(isText);
-  const chips = [
-    ...(alcohol.selectedTags ?? []),
-    alcohol.korCategory,
-    alcohol.regionName,
-  ].filter(isText);
+  const details = [alcohol.abv && `도수 ${alcohol.abv}%`].filter(isText);
+  const chips = [...(alcohol.selectedTags ?? [])].filter(isText);
   const alcoholContent = (
     <>
       <ItemImage


### PR DESCRIPTION
## Summary
- Hide curation lineup category and region values from rendered chips
- Keep user-selected tasting tags as the only lineup chips
- Remove category from the inline alcohol detail text

## Test
- pnpm lint