### PR TITLE
fix: 시음회 모집 인원 미정 표시

### DIFF
--- a/src/__tests__/components/TastingEventInfoCard.test.tsx
+++ b/src/__tests__/components/TastingEventInfoCard.test.tsx
@@ -38,3 +38,12 @@ describe('TastingEventInfoCard 장소 정보', () => {
     expect(address).not.toHaveClass('line-clamp-2', 'truncate');
   });
 });
+
+describe('TastingEventInfoCard 모집 인원 정보', () => {
+  it('모집 인원이 0명이면 모집 인원 미정으로 렌더링한다', () => {
+    render(<TastingEventInfoCard payload={{ ...payload, capacity: 0 }} />);
+
+    expect(screen.getByText('모집 인원 미정')).toBeInTheDocument();
+    expect(screen.queryByText('0명 정원')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(primary)/curation/_preview/buildTastingEventPreviewModel.ts
+++ b/src/app/(primary)/curation/_preview/buildTastingEventPreviewModel.ts
@@ -4,6 +4,7 @@ import type {
   TastingEventPreviewModel,
   TastingEventPreviewPayload,
 } from './types';
+import { getTastingEventCapacityLabel } from '../_utils/parseTastingEventPayload';
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -113,7 +114,7 @@ export const buildTastingEventPreviewModel = (
     eventDateTimeLabel: `${eventDateLabel} · ${eventTimeLabel}`,
     placeLabel: payload.placeName ?? payload.barAddress,
     fullAddress,
-    capacityLabel: `${payload.capacity.toLocaleString('ko-KR')}명 정원`,
+    capacityLabel: getTastingEventCapacityLabel(payload.capacity),
     entryFeeLabel:
       payload.entryFee > 0
         ? `${payload.entryFee.toLocaleString('ko-KR')}원`

--- a/src/app/(primary)/curation/_utils/parseTastingEventPayload.ts
+++ b/src/app/(primary)/curation/_utils/parseTastingEventPayload.ts
@@ -22,6 +22,11 @@ const splitDetailAddress = (
   };
 };
 
+export const getTastingEventCapacityLabel = (capacity: number) =>
+  capacity === 0
+    ? '모집 인원 미정'
+    : `${capacity.toLocaleString('ko-KR')}명 정원`;
+
 export function parseTastingEventPayload(payload: TastingEventPayload) {
   const eventDate = new Date(payload.eventDate);
   const eventDateLabel = Number.isNaN(eventDate.getTime())
@@ -47,7 +52,7 @@ export function parseTastingEventPayload(payload: TastingEventPayload) {
     eventDateTimeLabel: `${eventDateLabel} · ${eventTimeLabel}`,
     fullAddress,
     placeLabel,
-    capacityLabel: `${payload.capacity.toLocaleString('ko-KR')}명 정원`,
+    capacityLabel: getTastingEventCapacityLabel(payload.capacity),
     entryFeeLabel:
       payload.entryFee > 0
         ? `${payload.entryFee.toLocaleString('ko-KR')}원`


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- 없음

## PR 타입 (Type of Change)

- [ ] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 리팩토링
- [ ] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [ ] 🔧 chore: 설정/빌드 변경
- [x] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 시음회 모집 인원이 0명일 때 `모집 인원 미정`으로 표시되도록 공통 라벨 함수를 추가했습니다.
- 시음회 미리보기 모델도 동일한 모집 인원 라벨 규칙을 사용하도록 맞췄습니다.
- 0명 모집 인원 표시를 검증하는 컴포넌트 테스트를 추가했습니다.

## 변경 이유 (Reason for Changes)

- 모집 인원이 정해지지 않은 시음회를 `0명 정원`으로 표시하지 않기 위해 수정했습니다.

## 테스트 방법 (Test Procedure)

1. `pnpm test -- TastingEventInfoCard.test.tsx --runInBand`
2. `pnpm exec eslint 'src/app/(primary)/curation/_utils/parseTastingEventPayload.ts' 'src/app/(primary)/curation/_preview/buildTastingEventPreviewModel.ts'`

## 셀프 체크리스트 (Self Checklist)

- [x] 로컬에서 정상 동작 확인
- [ ] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [ ] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- 테스트 파일을 직접 ESLint에 포함하면 저장소의 기존 `import/no-extraneous-dependencies` 설정으로 `@testing-library/react` devDependency 경고가 발생해 소스 파일 lint만 별도로 확인했습니다.