### PR TITLE
fix: 짧은 리스트의 스크롤 UI 노출 상태 안정화

### DIFF
--- a/src/app/(primary)/explore/_components/ExploreSearchBar.test.tsx
+++ b/src/app/(primary)/explore/_components/ExploreSearchBar.test.tsx
@@ -2,7 +2,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ExploreSearchBar } from './ExploreSearchBar';
 
-const mockUseScrollState = jest.fn();
+const mockUseNavLayout = jest.fn();
 
 jest.mock('next/image', () => ({
   __esModule: true,
@@ -21,8 +21,8 @@ jest.mock('@/queries/useRegionsQuery', () => ({
   }),
 }));
 
-jest.mock('@/hooks/useScrollState', () => ({
-  useScrollState: () => mockUseScrollState(),
+jest.mock('@/components/ui/Layout/NavLayout', () => ({
+  useNavLayout: () => mockUseNavLayout(),
 }));
 
 jest.mock('../_hooks/useExploreFilters', () => ({
@@ -38,7 +38,7 @@ jest.mock('../_hooks/useExploreFilters', () => ({
 
 describe('ExploreSearchBar', () => {
   beforeEach(() => {
-    mockUseScrollState.mockReturnValue({ isVisible: true, isAtTop: true });
+    mockUseNavLayout.mockReturnValue({ isScrollVisible: true });
   });
 
   it('realtime 모드에서는 검색어 추가 버튼 없이 입력 변경을 전달한다', () => {
@@ -108,7 +108,7 @@ describe('ExploreSearchBar', () => {
       top: 'var(--explore-current-header-height)',
     });
 
-    mockUseScrollState.mockReturnValue({ isVisible: false, isAtTop: false });
+    mockUseNavLayout.mockReturnValue({ isScrollVisible: false });
     rerender(<ExploreSearchBar {...props} />);
 
     expect(searchBar).toHaveClass(

--- a/src/app/(primary)/explore/_components/ExploreSearchBar.tsx
+++ b/src/app/(primary)/explore/_components/ExploreSearchBar.tsx
@@ -3,8 +3,8 @@ import Image from 'next/image';
 import SideFilterDrawer from '@/components/feature/SideFilterDrawer';
 import { Accordion } from '@/components/feature/SideFilterDrawer/Accordion';
 import UnderlineSearchBar from '@/components/feature/Search/UnderlineSearchBar';
+import { useNavLayout } from '@/components/ui/Layout/NavLayout';
 import { CATEGORY_MENUS_LIST } from '@/constants/common';
-import { useScrollState } from '@/hooks/useScrollState';
 import { cn } from '@/lib/utils';
 import { useRegionsQuery } from '@/queries/useRegionsQuery';
 import type { SearchKeyword } from './types';
@@ -36,9 +36,9 @@ type Props = ChipSearchProps | RealtimeSearchProps;
 export const ExploreSearchBar = (props: Props) => {
   const { description, isFilter = false } = props;
   const isRealtime = props.mode === 'realtime';
-  const { isVisible } = useScrollState(100);
+  const { isScrollVisible } = useNavLayout();
   const isSearchActive = isRealtime && props.isSearchActive;
-  const shouldShowSearchBar = isSearchActive || isVisible;
+  const shouldShowSearchBar = isSearchActive || isScrollVisible;
   const [isOpenSideFilter, setIsOpenSideFilter] = useState(false);
   const { regions } = useRegionsQuery();
   const {

--- a/src/app/(primary)/explore/page.test.tsx
+++ b/src/app/(primary)/explore/page.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import ExplorePage from './page';
 
-const mockUseScrollState = jest.fn();
+const mockUseNavLayout = jest.fn();
 const mockSetNavbarSuppressed = jest.fn();
 const mockSetTabParam = jest.fn();
 const mockRouterReplace = jest.fn();
@@ -11,10 +11,6 @@ const mockRouterReplace = jest.fn();
 jest.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams('tab=REVIEW_WHISKEY'),
   useRouter: () => ({ replace: mockRouterReplace }),
-}));
-
-jest.mock('@/hooks/useScrollState', () => ({
-  useScrollState: () => mockUseScrollState(),
 }));
 
 jest.mock('@/hooks/useStatefulSearchParams', () => ({
@@ -32,7 +28,7 @@ jest.mock('@/hooks/useTab', () => ({
 }));
 
 jest.mock('@/components/ui/Layout/NavLayout', () => ({
-  useNavLayout: () => ({ setNavbarSuppressed: mockSetNavbarSuppressed }),
+  useNavLayout: () => mockUseNavLayout(),
 }));
 
 jest.mock('@/components/ui/Navigation/Tab', () => ({
@@ -68,7 +64,10 @@ describe('ExplorePage scroll header', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     window.scrollTo = jest.fn();
-    mockUseScrollState.mockReturnValue({ isVisible: true, isAtTop: true });
+    mockUseNavLayout.mockReturnValue({
+      isScrollVisible: true,
+      setNavbarSuppressed: mockSetNavbarSuppressed,
+    });
   });
 
   it('스크롤 상단에서는 BottleNote 로고 영역을 표시한다', () => {
@@ -82,7 +81,10 @@ describe('ExplorePage scroll header', () => {
   });
 
   it('아래로 스크롤하면 BottleNote 로고 영역을 접고 탭만 유지한다', () => {
-    mockUseScrollState.mockReturnValue({ isVisible: false, isAtTop: false });
+    mockUseNavLayout.mockReturnValue({
+      isScrollVisible: false,
+      setNavbarSuppressed: mockSetNavbarSuppressed,
+    });
 
     render(<ExplorePage />);
 

--- a/src/app/(primary)/explore/page.tsx
+++ b/src/app/(primary)/explore/page.tsx
@@ -8,7 +8,6 @@ import Tab from '@/components/ui/Navigation/Tab';
 import { SubHeader } from '@/components/ui/Navigation/SubHeader';
 import { useNavLayout } from '@/components/ui/Layout/NavLayout';
 import useStatefulSearchParams from '@/hooks/useStatefulSearchParams';
-import { useScrollState } from '@/hooks/useScrollState';
 import { cn } from '@/lib/utils';
 import { ReviewExplorerList } from './_components/ReviewExploreList';
 import { WhiskeyExplorerList } from './_components/WhiskeyExploreList';
@@ -18,12 +17,11 @@ type TabId = 'REVIEW_WHISKEY' | 'EXPLORER_WHISKEY';
 export default function ExplorePage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { setNavbarSuppressed } = useNavLayout();
+  const { isScrollVisible, setNavbarSuppressed } = useNavLayout();
   const [isSearchActive, setIsSearchActive] = useState(false);
-  const { isVisible: isHeaderVisible } = useScrollState(100);
   const [tabParam, setTabParam] = useStatefulSearchParams<TabId>('tab');
   const tabFromUrl = (tabParam as TabId | null) || 'REVIEW_WHISKEY';
-  const isHeaderCollapsed = isSearchActive || !isHeaderVisible;
+  const isHeaderCollapsed = isSearchActive || !isScrollVisible;
 
   const tabList = [
     { name: '리뷰 둘러보기', id: 'REVIEW_WHISKEY' },

--- a/src/components/ui/Layout/NavLayout.test.tsx
+++ b/src/components/ui/Layout/NavLayout.test.tsx
@@ -2,10 +2,25 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import NavLayout, { useNavLayout } from './NavLayout';
 
+jest.mock('@/hooks/useScrollState', () => ({
+  useScrollState: () => ({ isVisible: true, isAtTop: true }),
+}));
+
 jest.mock('@/components/ui/Navigation/Navbar', () => ({
   __esModule: true,
-  default: ({ isSuppressed }: { isSuppressed?: boolean }) => (
-    <nav data-suppressed={String(isSuppressed)}>navbar</nav>
+  default: ({
+    isSuppressed,
+    isScrollVisible,
+  }: {
+    isSuppressed?: boolean;
+    isScrollVisible?: boolean;
+  }) => (
+    <nav
+      data-suppressed={String(isSuppressed)}
+      data-scroll-visible={String(isScrollVisible)}
+    >
+      navbar
+    </nav>
   ),
 }));
 
@@ -34,6 +49,7 @@ describe('NavLayout', () => {
 
     const navbar = screen.getByRole('navigation');
     expect(navbar).toHaveAttribute('data-suppressed', 'false');
+    expect(navbar).toHaveAttribute('data-scroll-visible', 'true');
 
     fireEvent.click(screen.getByRole('button', { name: 'suppress' }));
     expect(navbar).toHaveAttribute('data-suppressed', 'true');

--- a/src/components/ui/Layout/NavLayout.tsx
+++ b/src/components/ui/Layout/NavLayout.tsx
@@ -2,9 +2,11 @@
 
 import React, { createContext, useContext, useMemo, useState } from 'react';
 import Navbar from '@/components/ui/Navigation/Navbar';
+import { useScrollState } from '@/hooks/useScrollState';
 
 interface NavLayoutContextValue {
   isNavbarSuppressed: boolean;
+  isScrollVisible: boolean;
   setNavbarSuppressed: (suppressed: boolean) => void;
 }
 
@@ -27,15 +29,21 @@ interface Props {
 
 export default function NavLayout({ showNavbar = true, children }: Props) {
   const [isNavbarSuppressed, setNavbarSuppressed] = useState(false);
+  const { isVisible: isScrollVisible } = useScrollState(100);
   const contextValue = useMemo(
-    () => ({ isNavbarSuppressed, setNavbarSuppressed }),
-    [isNavbarSuppressed],
+    () => ({ isNavbarSuppressed, isScrollVisible, setNavbarSuppressed }),
+    [isNavbarSuppressed, isScrollVisible],
   );
 
   return (
     <NavLayoutContext.Provider value={contextValue}>
       <main>{children}</main>
-      {showNavbar && <Navbar isSuppressed={isNavbarSuppressed} />}
+      {showNavbar && (
+        <Navbar
+          isSuppressed={isNavbarSuppressed}
+          isScrollVisible={isScrollVisible}
+        />
+      )}
     </NavLayoutContext.Provider>
   );
 }

--- a/src/components/ui/Navigation/Navbar.test.tsx
+++ b/src/components/ui/Navigation/Navbar.test.tsx
@@ -2,8 +2,6 @@
 import { render, screen } from '@testing-library/react';
 import Navbar from './Navbar';
 
-const mockUseScrollState = jest.fn();
-
 jest.mock('next/image', () => ({
   __esModule: true,
   default: ({
@@ -33,21 +31,21 @@ jest.mock('@/utils/flutterUtil', () => ({
   handleWebViewMessage: jest.fn(),
 }));
 
-jest.mock('@/hooks/useScrollState', () => ({
-  useScrollState: () => mockUseScrollState(),
-}));
-
 describe('Navbar suppression', () => {
-  beforeEach(() => {
-    mockUseScrollState.mockReturnValue({ isVisible: true, isAtTop: true });
-  });
-
   it('기본 상태에서는 scroll visibility에 따라 노출된다', () => {
     render(<Navbar />);
 
     const navbar = screen.getByRole('navigation');
     expect(navbar).toHaveClass('translate-y-0');
     expect(navbar).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('공유된 scroll visibility가 false이면 숨긴다', () => {
+    render(<Navbar isScrollVisible={false} />);
+
+    const navbar = screen.getByRole('navigation', { hidden: true });
+    expect(navbar).toHaveClass('pointer-events-none');
+    expect(navbar).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('suppression이 scroll visibility보다 우선한다', () => {

--- a/src/components/ui/Navigation/Navbar.tsx
+++ b/src/components/ui/Navigation/Navbar.tsx
@@ -7,7 +7,6 @@ import { useAuth } from '@/hooks/auth/useAuth';
 import useModalStore from '@/store/modalStore';
 import { ROUTES } from '@/constants/routes';
 import { handleWebViewMessage } from '@/utils/flutterUtil';
-import { useScrollState } from '@/hooks/useScrollState';
 import { cn } from '@/lib/utils';
 
 export interface NavItem {
@@ -20,17 +19,21 @@ export interface NavItem {
 interface NavbarProps {
   maxWidth?: string;
   isSuppressed?: boolean;
+  isScrollVisible?: boolean;
 }
 
-function Navbar({ maxWidth, isSuppressed = false }: NavbarProps) {
+function Navbar({
+  maxWidth,
+  isSuppressed = false,
+  isScrollVisible = true,
+}: NavbarProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { user: userData, isLoggedIn } = useAuth();
   const { handleLoginModal } = useModalStore();
   const [isMounted, setIsMounted] = useState(false);
   const [lastTapTime, setLastTapTime] = useState<{ [key: string]: number }>({});
-  const { isVisible } = useScrollState(100);
-  const shouldShowNavbar = isVisible && !isSuppressed;
+  const shouldShowNavbar = isScrollVisible && !isSuppressed;
 
   useEffect(() => {
     setIsMounted(true);

--- a/src/hooks/useScrollState.test.tsx
+++ b/src/hooks/useScrollState.test.tsx
@@ -1,0 +1,75 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act, renderHook } from '@testing-library/react';
+import { useScrollState } from './useScrollState';
+
+jest.mock('@/utils/throttle', () => ({
+  throttle: (handler: () => void) => handler,
+}));
+
+const setScrollMetrics = ({
+  scrollY,
+  scrollHeight,
+  innerHeight = 800,
+}: {
+  scrollY: number;
+  scrollHeight: number;
+  innerHeight?: number;
+}) => {
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    value: scrollY,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: innerHeight,
+  });
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    configurable: true,
+    value: scrollHeight,
+  });
+};
+
+const dispatchScroll = () => {
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
+  });
+};
+
+describe('useScrollState', () => {
+  beforeEach(() => {
+    setScrollMetrics({ scrollY: 0, scrollHeight: 1300 });
+  });
+
+  it('짧은 목록에서는 실제 스크롤 범위에 맞춰 숨김 기준을 낮춘다', () => {
+    setScrollMetrics({ scrollY: 0, scrollHeight: 870 });
+    const { result } = renderHook(() => useScrollState(100));
+
+    setScrollMetrics({ scrollY: 40, scrollHeight: 870 });
+    dispatchScroll();
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.isAtTop).toBe(false);
+  });
+
+  it('목록 축소로 scrollY가 보정되면 위쪽 스크롤로 오인하지 않는다', () => {
+    const { result } = renderHook(() => useScrollState(100));
+
+    setScrollMetrics({ scrollY: 150, scrollHeight: 1300 });
+    dispatchScroll();
+    expect(result.current.isVisible).toBe(false);
+
+    setScrollMetrics({ scrollY: 70, scrollHeight: 870 });
+    dispatchScroll();
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('스크롤할 수 없는 목록에서는 UI를 표시한다', () => {
+    setScrollMetrics({ scrollY: 0, scrollHeight: 800 });
+    const { result } = renderHook(() => useScrollState(100));
+
+    dispatchScroll();
+
+    expect(result.current).toEqual({ isVisible: true, isAtTop: true });
+  });
+});

--- a/src/hooks/useScrollState.ts
+++ b/src/hooks/useScrollState.ts
@@ -8,30 +8,70 @@ interface ScrollState {
   isAtTop: boolean;
 }
 
+const MIN_SCROLLABLE_DISTANCE = 1;
+const SCROLL_DELTA_THRESHOLD = 10;
+
 export const useScrollState = (threshold = 100) => {
   const [scrollState, setScrollState] = useState<ScrollState>({
     isVisible: true,
     isAtTop: true,
   });
   const lastScrollY = useRef(0);
+  const lastMaxScrollY = useRef(0);
 
   useEffect(() => {
     const handleScroll = throttle(() => {
       const currentScrollY = window.scrollY;
-      const scrollThreshold = 10;
+      const maxScrollY = Math.max(
+        0,
+        document.documentElement.scrollHeight - window.innerHeight,
+      );
 
-      if (Math.abs(currentScrollY - lastScrollY.current) < scrollThreshold) {
+      if (maxScrollY <= MIN_SCROLLABLE_DISTANCE) {
+        setScrollState((previous) =>
+          previous.isVisible && previous.isAtTop
+            ? previous
+            : { isVisible: true, isAtTop: true },
+        );
+        lastScrollY.current = currentScrollY;
+        lastMaxScrollY.current = maxScrollY;
         return;
       }
 
-      const isAtTop = currentScrollY < threshold;
-      const isScrollingDown = currentScrollY > lastScrollY.current;
-      const isVisible = !isScrollingDown || currentScrollY <= threshold;
+      const hideThreshold = Math.min(threshold, maxScrollY / 2);
+      const scrollDeltaThreshold = Math.min(
+        SCROLL_DELTA_THRESHOLD,
+        hideThreshold,
+      );
+      const isAtTop = currentScrollY < hideThreshold;
 
-      setScrollState({
-        isVisible,
-        isAtTop,
-      });
+      if (
+        lastMaxScrollY.current > maxScrollY &&
+        lastScrollY.current > maxScrollY
+      ) {
+        setScrollState((previous) =>
+          previous.isAtTop === isAtTop ? previous : { ...previous, isAtTop },
+        );
+        lastScrollY.current = currentScrollY;
+        lastMaxScrollY.current = maxScrollY;
+        return;
+      }
+
+      lastMaxScrollY.current = maxScrollY;
+      const scrollDelta = currentScrollY - lastScrollY.current;
+
+      if (Math.abs(scrollDelta) < scrollDeltaThreshold) {
+        return;
+      }
+
+      const isScrollingDown = scrollDelta > 0;
+      const isVisible = isAtTop || !isScrollingDown;
+
+      setScrollState((previous) =>
+        previous.isVisible === isVisible && previous.isAtTop === isAtTop
+          ? previous
+          : { isVisible, isAtTop },
+      );
 
       lastScrollY.current = currentScrollY;
     }, 16);


### PR DESCRIPTION
## 요약

- 실제 최대 스크롤 범위에 맞춰 헤더·내비게이션 숨김 임계값을 동적으로 계산합니다.
- 리스트 축소로 브라우저가 `scrollY`를 보정하는 상황을 위쪽 스크롤로 오인하지 않도록 처리합니다.
- Explore 헤더, 검색바, 하단 Navbar가 `NavLayout`의 단일 스크롤 상태를 공유하도록 통합합니다.
- 짧은 목록, 목록 축소, 스크롤 불가 상태에 대한 회귀 테스트를 추가합니다.

## 문제

목록이 짧아 최대 `scrollY`가 고정 임계값 100px보다 작아지면 상단 헤더와 하단 Navbar가 숨김 조건에 도달하지 못했습니다. 목록 높이가 동적으로 줄어들 때는 브라우저가 보정한 `scrollY` 감소를 위쪽 스크롤로 판단하는 문제도 있었습니다.

## 테스트

- `pnpm exec jest --runTestsByPath src/hooks/useScrollState.test.tsx src/components/ui/Layout/NavLayout.test.tsx src/components/ui/Navigation/Navbar.test.tsx 'src/app/(primary)/explore/page.test.tsx' 'src/app/(primary)/explore/_components/ExploreSearchBar.test.tsx' --runInBand`
- 5 suites, 13 tests passed
