### PR TITLE
fix: 마이보틀 무한스크롤 안정화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Instructions
+
+## Browser Debugging
+
+- Use the Playwright MCP for browser-based debugging and local UI verification in this workspace.
+- Do not substitute another browser-control tool or standalone browser automation when the Playwright MCP is available.
+- If the flow requires authentication, do not bypass or mock it. Ask the user to sign in, then resume after the user confirms that login is complete.
+- Reuse the authenticated Playwright MCP browser session for subsequent checks.
+- Reproduce issues at the viewport size and document scroll height reported by the user.
+- For infinite-scroll debugging, compare network requests before scrolling with requests made after the sentinel enters the viewport.

--- a/src/app/(primary)/user/[id]/my-bottle/page.tsx
+++ b/src/app/(primary)/user/[id]/my-bottle/page.tsx
@@ -71,7 +71,6 @@ export default function MyBottle({
     data: alcoholList,
     isLoading: isFirstLoading,
     isFetching,
-    hasNextPage,
     targetRef,
   } = usePaginatedQuery<
     | RatingMyBottleListResponse
@@ -200,58 +199,61 @@ export default function MyBottle({
             />
 
             <List.Section>
-              {alcoholList &&
-                [...alcoholList.map((list) => list.data.myBottleList)]
-                  .flat()
-                  .map((item) => {
-                    if (currentTab.id === 'ratings') {
-                      return (
-                        <RatingsListItem
-                          data={
-                            item as RatingMyBottleListResponse['myBottleList'][number]
-                          }
-                          isMyPage={alcoholList[0].data.isMyPage}
-                          key={item.baseMyBottleInfo.alcoholId}
-                        />
-                      );
-                    }
+              {alcoholList && (
+                <>
+                  {[...alcoholList.map((list) => list.data.myBottleList)]
+                    .flat()
+                    .map((item) => {
+                      if (currentTab.id === 'ratings') {
+                        return (
+                          <RatingsListItem
+                            data={
+                              item as RatingMyBottleListResponse['myBottleList'][number]
+                            }
+                            isMyPage={alcoholList[0].data.isMyPage}
+                            key={item.baseMyBottleInfo.alcoholId}
+                          />
+                        );
+                      }
 
-                    if (currentTab.id === 'reviews') {
-                      return (
-                        <ReviewListItem
-                          data={
-                            item as ReviewMyBottleListResponse['myBottleList'][number]
-                          }
-                          key={
-                            (
+                      if (currentTab.id === 'reviews') {
+                        return (
+                          <ReviewListItem
+                            data={
                               item as ReviewMyBottleListResponse['myBottleList'][number]
-                            ).reviewId
-                          }
-                        />
-                      );
-                    }
+                            }
+                            key={
+                              (
+                                item as ReviewMyBottleListResponse['myBottleList'][number]
+                              ).reviewId
+                            }
+                          />
+                        );
+                      }
 
-                    if (currentTab.id === 'picks') {
-                      return (
-                        <PicksListItem
-                          data={
-                            item as PickMyBottleListResponse['myBottleList'][number]
-                          }
-                          isMyPage={isMyPage}
-                          key={
-                            (
+                      if (currentTab.id === 'picks') {
+                        return (
+                          <PicksListItem
+                            data={
                               item as PickMyBottleListResponse['myBottleList'][number]
-                            ).baseMyBottleInfo.alcoholId
-                          }
-                        />
-                      );
-                    }
+                            }
+                            isMyPage={isMyPage}
+                            key={
+                              (
+                                item as PickMyBottleListResponse['myBottleList'][number]
+                              ).baseMyBottleInfo.alcoholId
+                            }
+                          />
+                        );
+                      }
 
-                    return <></>;
-                  })}
+                      return <></>;
+                    })}
+                  <div ref={targetRef} className="h-1" />
+                </>
+              )}
             </List.Section>
           </List>
-          {hasNextPage && <div ref={targetRef} className="h-1" />}
         </section>
       </main>
     </Suspense>

--- a/src/app/(primary)/user/[id]/my-bottle/page.tsx
+++ b/src/app/(primary)/user/[id]/my-bottle/page.tsx
@@ -36,6 +36,11 @@ interface InitialState {
 
 const SORT_OPTIONS = [{ name: '최신순', type: SORT_TYPE.LATEST }];
 
+const MY_BOTTLE_INTERSECTION_OPTIONS: IntersectionObserverInit = {
+  rootMargin: '0px',
+  threshold: 0,
+};
+
 export default function MyBottle({
   params: { id: userId },
 }: {
@@ -71,6 +76,7 @@ export default function MyBottle({
     data: alcoholList,
     isLoading: isFirstLoading,
     isFetching,
+    hasNextPage,
     targetRef,
   } = usePaginatedQuery<
     | RatingMyBottleListResponse
@@ -90,6 +96,7 @@ export default function MyBottle({
         userId: Number(userId),
       });
     },
+    intersectionOptions: MY_BOTTLE_INTERSECTION_OPTIONS,
   });
 
   const { data: userInfo } = useQuery({
@@ -249,7 +256,7 @@ export default function MyBottle({
 
                       return <></>;
                     })}
-                  <div ref={targetRef} className="h-1" />
+                  {hasNextPage && <div ref={targetRef} className="h-1" />}
                 </>
               )}
             </List.Section>

--- a/src/app/(primary)/user/[id]/my-bottle/page.tsx
+++ b/src/app/(primary)/user/[id]/my-bottle/page.tsx
@@ -71,6 +71,7 @@ export default function MyBottle({
     data: alcoholList,
     isLoading: isFirstLoading,
     isFetching,
+    hasNextPage,
     targetRef,
   } = usePaginatedQuery<
     | RatingMyBottleListResponse
@@ -250,7 +251,7 @@ export default function MyBottle({
                   })}
             </List.Section>
           </List>
-          <div ref={targetRef} />
+          {hasNextPage && <div ref={targetRef} className="h-1" />}
         </section>
       </main>
     </Suspense>

--- a/src/components/domain/alcohol/AlcoholPickButton.tsx
+++ b/src/components/domain/alcohol/AlcoholPickButton.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '@/hooks/auth/useAuth';
 import { useDebouncedToggle } from '@/hooks/useDebouncedToggle';
 import { trackGA4Event } from '@/utils/analytics/ga4';
 
+const PICK_DEBOUNCE_DELAY_MS = 500;
+
 interface Props {
   isPicked: boolean;
   handleUpdatePicked?: () => void;
@@ -41,6 +43,7 @@ const AlcoholPickButton = ({
       await AlcoholsApi.putPick({ alcoholId: id, isPicked: state });
     },
     id: alcoholId,
+    debounceDelay: PICK_DEBOUNCE_DELAY_MS,
     onApiSuccess,
     onApiError,
     errorMessage: '찜하기 업데이트에 실패했습니다. 다시 시도해주세요.',

--- a/src/components/domain/history/TimelineFull.tsx
+++ b/src/components/domain/history/TimelineFull.tsx
@@ -21,7 +21,7 @@ export interface TimelineFullProps {
   handleOpenFilterModal: () => void;
   shouldReset?: boolean;
   onResetComplete?: () => void;
-  targetRef?: React.RefObject<HTMLDivElement>;
+  targetRef?: React.Ref<HTMLDivElement>;
   isFetching?: boolean;
 }
 

--- a/src/hooks/useDebouncedToggle.ts
+++ b/src/hooks/useDebouncedToggle.ts
@@ -7,6 +7,7 @@ interface UseDebouncedToggleParams<T> {
   isToggled: boolean;
   apiCall: (params: { id: T; state: boolean }) => Promise<void>;
   id: T;
+  debounceDelay?: number;
   onApiSuccess?: () => void;
   onApiError?: () => void;
   errorMessage: string;
@@ -16,12 +17,13 @@ export const useDebouncedToggle = <T extends string | number>({
   isToggled,
   apiCall,
   id,
+  debounceDelay = DEBOUNCE_DELAY,
   onApiSuccess,
   onApiError,
   errorMessage,
 }: UseDebouncedToggleParams<T>) => {
   const { handleModalState } = useModalStore();
-  const { debounce } = useDebounceAction(DEBOUNCE_DELAY);
+  const { debounce } = useDebounceAction(debounceDelay);
 
   const lastSyncedStateRef = useRef(isToggled);
   const pendingStateRef = useRef<boolean | null>(null);

--- a/src/hooks/useInfiniteScroll.test.tsx
+++ b/src/hooks/useInfiniteScroll.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+
+interface HarnessProps {
+  fetchNextPage: () => void;
+  showTarget: boolean;
+  throttleMs?: number;
+}
+
+const Harness = ({ fetchNextPage, showTarget, throttleMs }: HarnessProps) => {
+  const { targetRef } = useInfiniteScroll({
+    fetchNextPage,
+    throttleMs,
+  });
+
+  return showTarget ? (
+    <div ref={targetRef} data-testid="scroll-target" />
+  ) : null;
+};
+
+describe('useInfiniteScroll', () => {
+  const observe = jest.fn();
+  const unobserve = jest.fn();
+  let observerCallback: IntersectionObserverCallback;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.IntersectionObserver = jest
+      .fn()
+      .mockImplementation((callback: IntersectionObserverCallback) => {
+        observerCallback = callback;
+        return {
+          observe,
+          unobserve,
+        };
+      });
+  });
+
+  it('마운트가 늦어진 target도 관찰한다', () => {
+    const fetchNextPage = jest.fn();
+    const { rerender } = render(
+      <Harness fetchNextPage={fetchNextPage} showTarget={false} />,
+    );
+
+    rerender(<Harness fetchNextPage={fetchNextPage} showTarget />);
+
+    expect(window.IntersectionObserver).toHaveBeenCalledTimes(1);
+    expect(observe).toHaveBeenCalledWith(screen.getByTestId('scroll-target'));
+  });
+
+  it('같은 교차 구간에서는 한 번만 요청하고 재진입 시 다시 요청한다', () => {
+    const fetchNextPage = jest.fn();
+    const { rerender } = render(
+      <Harness fetchNextPage={fetchNextPage} showTarget throttleMs={0} />,
+    );
+
+    observerCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+
+    observerCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+
+    observerCallback(
+      [{ isIntersecting: false } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+    observerCallback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    expect(fetchNextPage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const DEFAULT_THROTTLE_MS = 100;
 
@@ -13,39 +13,80 @@ export const useInfiniteScroll = ({
   options,
   throttleMs = DEFAULT_THROTTLE_MS,
 }: Props) => {
-  const targetRef = useRef<HTMLDivElement | null>(null);
+  const [target, setTarget] = useState<HTMLDivElement | null>(null);
   const fetchRef = useRef(fetchNextPage);
+  const isIntersectingRef = useRef(false);
+  const hasTriggeredForCurrentIntersectionRef = useRef(false);
   const lastTriggerTimeRef = useRef(0);
+  const pendingTriggerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   fetchRef.current = fetchNextPage;
+  const targetRef = useCallback((node: HTMLDivElement | null) => {
+    setTarget(node);
+  }, []);
+
+  const clearPendingTrigger = useCallback(() => {
+    if (pendingTriggerRef.current === null) return;
+
+    clearTimeout(pendingTriggerRef.current);
+    pendingTriggerRef.current = null;
+  }, []);
+
+  const triggerFetch = useCallback(() => {
+    if (!isIntersectingRef.current) return;
+
+    const now = Date.now();
+    const elapsedSinceLastTrigger = now - lastTriggerTimeRef.current;
+    const remainingThrottleMs = throttleMs - elapsedSinceLastTrigger;
+
+    if (throttleMs > 0 && remainingThrottleMs > 0) {
+      if (pendingTriggerRef.current !== null) return;
+
+      pendingTriggerRef.current = setTimeout(() => {
+        pendingTriggerRef.current = null;
+
+        if (!isIntersectingRef.current) return;
+
+        lastTriggerTimeRef.current = Date.now();
+        fetchRef.current();
+      }, remainingThrottleMs);
+      return;
+    }
+
+    lastTriggerTimeRef.current = now;
+    fetchRef.current();
+  }, [throttleMs]);
 
   const observerCallback = useCallback(
     (entries: IntersectionObserverEntry[]) => {
-      if (!entries[0]?.isIntersecting) return;
+      isIntersectingRef.current = Boolean(entries[0]?.isIntersecting);
 
-      const now = Date.now();
-      const elapsedSinceLastTrigger = now - lastTriggerTimeRef.current;
-      const isWithinThrottleWindow =
-        throttleMs > 0 && elapsedSinceLastTrigger < throttleMs;
-
-      if (isWithinThrottleWindow) {
+      if (!isIntersectingRef.current) {
+        hasTriggeredForCurrentIntersectionRef.current = false;
+        clearPendingTrigger();
         return;
       }
 
-      lastTriggerTimeRef.current = now;
-      fetchRef.current();
+      if (hasTriggeredForCurrentIntersectionRef.current) return;
+
+      hasTriggeredForCurrentIntersectionRef.current = true;
+      triggerFetch();
     },
-    [throttleMs],
+    [clearPendingTrigger, triggerFetch],
   );
 
   useEffect(() => {
-    const target = targetRef.current;
     if (!target) return;
 
     const observer = new IntersectionObserver(observerCallback, options);
 
     observer.observe(target);
-    return () => observer.unobserve(target);
-  }, [observerCallback, options]);
+    return () => {
+      isIntersectingRef.current = false;
+      hasTriggeredForCurrentIntersectionRef.current = false;
+      clearPendingTrigger();
+      observer.unobserve(target);
+    };
+  }, [clearPendingTrigger, observerCallback, options, target]);
 
   return { targetRef };
 };


### PR DESCRIPTION
## 변경 사항

- 마이보틀 sentinel을 List 바깥에서 제거하고 List.Section 내부에서 목록 데이터와 함께 마운트합니다.
- 초기 fetch 전에 교차 이벤트가 소비되는 문제를 방지해 모바일과 데스크톱 모두에서 다음 페이지를 불러옵니다.
- Suspense 하위에서 늦게 마운트되는 sentinel도 callback ref로 관찰합니다.
- 동일한 IntersectionObserver 교차 구간에서는 다음 페이지를 한 번만 요청합니다.
- 찜 토글 디바운스를 다른 토글과 분리해 500ms로 단축합니다.

## 검증

- Playwright 총 11개 시나리오: 모바일 390×844 및 데스크톱 1440×1200에서 cursor 0 → 10, 11개 렌더링
- Playwright 데스크톱 총 31개 시나리오: 초기 cursor 0 → 10, 이후 스크롤마다 cursor 20과 30을 각각 한 번만 호출
- sentinel이 List.Section 내부 DOM에 연결된 것을 확인
- Jest 35 suites, 206 tests 통과
- ESLint 및 Prettier 통과