### PR TITLE
feat: 위스키 둘러보기 문의 버튼 및 로그인 복귀 경로 개선

### DIFF
--- a/src/app/(primary)/explore/_components/WhiskeyExploreList.test.tsx
+++ b/src/app/(primary)/explore/_components/WhiskeyExploreList.test.tsx
@@ -2,9 +2,19 @@
 import { render, screen } from '@testing-library/react';
 import { ExploreApi } from '@/api/explore/explore.api';
 import { usePaginatedQuery } from '@/queries/usePaginatedQuery';
+import { useAuth } from '@/hooks/auth/useAuth';
+import useModalStore from '@/store/modalStore';
+import { ROUTES } from '@/constants/routes';
+import type { LinkData } from '@/types/LinkButton';
 import { WhiskeyExplorerList } from './WhiskeyExploreList';
 import { useExploreFilters } from '../_hooks/useExploreFilters';
 import { useWhiskeyExploreSearch } from '../_hooks/useWhiskeyExploreSearch';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
 
 jest.mock('@/api/explore/explore.api', () => ({
   ExploreApi: { getAlcohols: jest.fn() },
@@ -20,6 +30,29 @@ jest.mock('../_hooks/useExploreFilters', () => ({
 
 jest.mock('../_hooks/useWhiskeyExploreSearch', () => ({
   useWhiskeyExploreSearch: jest.fn(),
+}));
+
+jest.mock('@/hooks/auth/useAuth', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/store/modalStore', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@/components/ui/Button/PrimaryLinkButton', () => ({
+  __esModule: true,
+  default: ({ data }: { data: LinkData }) => {
+    const href =
+      typeof data.linkSrc === 'string' ? data.linkSrc : data.linkSrc.pathname;
+
+    return (
+      <a href={href} onClick={data.handleBeforeRouteChange}>
+        {data.korName}
+      </a>
+    );
+  },
 }));
 
 jest.mock('./ExploreSearchBar', () => ({
@@ -67,6 +100,12 @@ const mockUsePaginatedQuery = usePaginatedQuery as jest.Mock;
 const mockUseExploreFilters = useExploreFilters as jest.Mock;
 const mockUseWhiskeyExploreSearch = useWhiskeyExploreSearch as jest.Mock;
 const mockGetAlcohols = ExploreApi.getAlcohols as jest.Mock;
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseModalStore = useModalStore as unknown as jest.Mock;
+
+const mockHandleModalState = jest.fn();
+const mockHandleCloseModal = jest.fn();
+const mockHandleLoginModal = jest.fn();
 
 describe('WhiskeyExplorerList realtime search', () => {
   beforeEach(() => {
@@ -81,12 +120,19 @@ describe('WhiskeyExplorerList realtime search', () => {
       regionIds: [12],
       category: 'SINGLE_MALT',
     });
+    mockUseAuth.mockReturnValue({ isLoggedIn: true });
+    mockUseModalStore.mockReturnValue({
+      handleModalState: mockHandleModalState,
+      handleCloseModal: mockHandleCloseModal,
+      handleLoginModal: mockHandleLoginModal,
+    });
     mockUsePaginatedQuery.mockReturnValue({
-      data: [],
+      data: [{ data: { items: [{ alcoholId: 1 }] } }],
       isLoading: false,
       isFetching: false,
       isFetchingNextPage: false,
       isPlaceholderData: false,
+      hasNextPage: true,
       targetRef: { current: null },
       error: null,
     });
@@ -133,5 +179,102 @@ describe('WhiskeyExplorerList realtime search', () => {
       pageSize: 10,
       signal: controller.signal,
     });
+  });
+
+  it('검색 결과가 없으면 위스키 추가 문의 버튼을 노출한다', () => {
+    mockUsePaginatedQuery.mockReturnValue({
+      data: [{ data: { items: [] } }],
+      isLoading: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isPlaceholderData: false,
+      hasNextPage: false,
+      targetRef: { current: null },
+      error: null,
+    });
+
+    render(
+      <WhiskeyExplorerList
+        isSearchActive={false}
+        onSearchActiveChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: '혹시 찾는 술이 없으신가요?' }),
+    ).toBeInTheDocument();
+  });
+
+  it('위스키 리스트의 마지막 페이지에 도달하면 문의 버튼을 노출한다', () => {
+    mockUsePaginatedQuery.mockReturnValue({
+      data: [{ data: { items: [{ alcoholId: 1 }] } }],
+      isLoading: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isPlaceholderData: false,
+      hasNextPage: false,
+      targetRef: { current: null },
+      error: null,
+    });
+
+    render(
+      <WhiskeyExplorerList
+        isSearchActive={false}
+        onSearchActiveChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: '혹시 찾는 술이 없으신가요?' }),
+    ).toBeInTheDocument();
+  });
+
+  it('다음 페이지가 남아 있으면 문의 버튼을 노출하지 않는다', () => {
+    render(
+      <WhiskeyExplorerList
+        isSearchActive={false}
+        onSearchActiveChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: '혹시 찾는 술이 없으신가요?' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('문의 버튼에서 기존 위스키 추가 요청 확인 흐름을 실행한다', () => {
+    mockUsePaginatedQuery.mockReturnValue({
+      data: [{ data: { items: [] } }],
+      isLoading: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isPlaceholderData: false,
+      hasNextPage: false,
+      targetRef: { current: null },
+      error: null,
+    });
+
+    render(
+      <WhiskeyExplorerList
+        isSearchActive={false}
+        onSearchActiveChange={jest.fn()}
+      />,
+    );
+
+    screen.getByRole('link', { name: '혹시 찾는 술이 없으신가요?' }).click();
+
+    expect(mockHandleModalState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isShowModal: true,
+        type: 'CONFIRM',
+        mainText: '위스키 추가 요청을 하겠습니까?',
+      }),
+    );
+
+    const modalState = mockHandleModalState.mock.calls[0][0];
+    modalState.handleConfirm();
+
+    expect(mockHandleCloseModal).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.INQUIRE.REGISTER);
   });
 });

--- a/src/app/(primary)/explore/_components/WhiskeyExploreList.test.tsx
+++ b/src/app/(primary)/explore/_components/WhiskeyExploreList.test.tsx
@@ -105,7 +105,7 @@ const mockUseModalStore = useModalStore as unknown as jest.Mock;
 
 const mockHandleModalState = jest.fn();
 const mockHandleCloseModal = jest.fn();
-const mockHandleLoginModal = jest.fn();
+const mockHandleLoginState = jest.fn();
 
 describe('WhiskeyExplorerList realtime search', () => {
   beforeEach(() => {
@@ -124,7 +124,7 @@ describe('WhiskeyExplorerList realtime search', () => {
     mockUseModalStore.mockReturnValue({
       handleModalState: mockHandleModalState,
       handleCloseModal: mockHandleCloseModal,
-      handleLoginModal: mockHandleLoginModal,
+      handleLoginState: mockHandleLoginState,
     });
     mockUsePaginatedQuery.mockReturnValue({
       data: [{ data: { items: [{ alcoholId: 1 }] } }],
@@ -276,5 +276,37 @@ describe('WhiskeyExplorerList realtime search', () => {
 
     expect(mockHandleCloseModal).toHaveBeenCalled();
     expect(mockPush).toHaveBeenCalledWith(ROUTES.INQUIRE.REGISTER);
+  });
+
+  it('비로그인 문의 요청은 로그인 후 문의 등록으로 이동할 returnTo를 지정한다', () => {
+    mockUseAuth.mockReturnValue({ isLoggedIn: false });
+    mockUsePaginatedQuery.mockReturnValue({
+      data: [{ data: { items: [] } }],
+      isLoading: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isPlaceholderData: false,
+      hasNextPage: false,
+      targetRef: { current: null },
+      error: null,
+    });
+
+    render(
+      <WhiskeyExplorerList
+        isSearchActive={false}
+        onSearchActiveChange={jest.fn()}
+      />,
+    );
+
+    screen.getByRole('link', { name: '혹시 찾는 술이 없으신가요?' }).click();
+    const modalState = mockHandleModalState.mock.calls[0][0];
+    modalState.handleConfirm();
+
+    expect(mockHandleCloseModal).toHaveBeenCalled();
+    expect(mockHandleLoginState).toHaveBeenCalledWith(
+      true,
+      ROUTES.INQUIRE.REGISTER,
+    );
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(primary)/explore/_components/WhiskeyExploreList.tsx
+++ b/src/app/(primary)/explore/_components/WhiskeyExploreList.tsx
@@ -23,7 +23,7 @@ export const WhiskeyExplorerList = ({
 }: WhiskeyExplorerListProps) => {
   const router = useRouter();
   const { isLoggedIn } = useAuth();
-  const { handleModalState, handleCloseModal, handleLoginModal } =
+  const { handleModalState, handleCloseModal, handleLoginState } =
     useModalStore();
   const { inputKeyword, debouncedKeyword, isTyping, setInputKeyword } =
     useWhiskeyExploreSearch();
@@ -94,7 +94,7 @@ export const WhiskeyExplorerList = ({
       handleConfirm: () => {
         if (!isLoggedIn) {
           handleCloseModal();
-          handleLoginModal();
+          handleLoginState(true, ROUTES.INQUIRE.REGISTER);
           return;
         }
         handleCloseModal();

--- a/src/app/(primary)/explore/_components/WhiskeyExploreList.tsx
+++ b/src/app/(primary)/explore/_components/WhiskeyExploreList.tsx
@@ -1,7 +1,12 @@
+import { useRouter } from 'next/navigation';
 import { ExploreApi } from '@/api/explore/explore.api';
 import type { ExploreAlcohol } from '@/api/explore/types';
 import { usePaginatedQuery } from '@/queries/usePaginatedQuery';
 import List from '@/components/feature/List/List';
+import PrimaryLinkButton from '@/components/ui/Button/PrimaryLinkButton';
+import { useAuth } from '@/hooks/auth/useAuth';
+import useModalStore from '@/store/modalStore';
+import { ROUTES } from '@/constants/routes';
 import WhiskeyListItem from './WhiskeyListItem';
 import { ExploreSearchBar } from './ExploreSearchBar';
 import { useExploreFilters } from '../_hooks/useExploreFilters';
@@ -16,6 +21,10 @@ export const WhiskeyExplorerList = ({
   isSearchActive,
   onSearchActiveChange,
 }: WhiskeyExplorerListProps) => {
+  const router = useRouter();
+  const { isLoggedIn } = useAuth();
+  const { handleModalState, handleCloseModal, handleLoginModal } =
+    useModalStore();
   const { inputKeyword, debouncedKeyword, isTyping, setInputKeyword } =
     useWhiskeyExploreSearch();
   const { regionIds, category } = useExploreFilters();
@@ -26,6 +35,7 @@ export const WhiskeyExplorerList = ({
     isFetching,
     isFetchingNextPage,
     isPlaceholderData,
+    hasNextPage,
     targetRef,
     error,
   } = usePaginatedQuery<{
@@ -55,10 +65,43 @@ export const WhiskeyExplorerList = ({
 
   const isSearching = isFetching && !isFetchingNextPage;
   const isEmpty =
+    !error &&
     !isTyping &&
     !isSearching &&
     !isPlaceholderData &&
     (!alcoholList || alcoholList[0]?.data.items.length === 0);
+
+  const alcoholCount =
+    alcoholList?.reduce(
+      (count, listData) => count + listData.data.items.length,
+      0,
+    ) ?? 0;
+  const hasReachedEnd =
+    !isFirstLoading &&
+    !isFetching &&
+    !isPlaceholderData &&
+    !error &&
+    alcoholList !== undefined &&
+    hasNextPage === false;
+  const showInquireButton = isEmpty || (hasReachedEnd && alcoholCount > 0);
+
+  const handleClickInquire = () => {
+    handleModalState({
+      isShowModal: true,
+      type: 'CONFIRM',
+      mainText: '위스키 추가 요청을 하겠습니까?',
+      subText: '문의글을 작성하여 위스키를 요청할까요?',
+      handleConfirm: () => {
+        if (!isLoggedIn) {
+          handleCloseModal();
+          handleLoginModal();
+          return;
+        }
+        handleCloseModal();
+        router.push(ROUTES.INQUIRE.REGISTER);
+      },
+    });
+  };
 
   return (
     <section>
@@ -96,6 +139,22 @@ export const WhiskeyExplorerList = ({
         </List.Section>
       </List>
       <div ref={targetRef} />
+      {showInquireButton && (
+        <div className="pt-7 pb-20">
+          <PrimaryLinkButton
+            data={{
+              engName: 'NO RESULTS',
+              korName: '혹시 찾는 술이 없으신가요?',
+              linkSrc: ROUTES.INQUIRE.REGISTER,
+              icon: true,
+              handleBeforeRouteChange: (event) => {
+                event.preventDefault();
+                handleClickInquire();
+              },
+            }}
+          />
+        </div>
+      )}
     </section>
   );
 };

--- a/src/app/(primary)/layout.tsx
+++ b/src/app/(primary)/layout.tsx
@@ -10,7 +10,7 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const { loginState, handleLoginModal } = useModalStore();
+  const { loginState, handleLoginState } = useModalStore();
   const { initWebView, isMobile } = useWebViewInit();
 
   useEffect(() => {
@@ -21,7 +21,10 @@ export default function Layout({
     <div className="bg-white flex flex-col w-full mx-auto min-h-safe-screen">
       <main>{children}</main>
       {loginState.isShowLoginModal && (
-        <LoginModal handleClose={handleLoginModal} />
+        <LoginModal
+          handleClose={() => handleLoginState(false)}
+          returnTo={loginState.returnTo}
+        />
       )}
     </div>
   );

--- a/src/app/(primary)/search/page.tsx
+++ b/src/app/(primary)/search/page.tsx
@@ -114,7 +114,7 @@ export default function Search() {
     staleTime: 0,
   });
 
-  const { handleModalState, handleCloseModal, handleLoginModal } =
+  const { handleModalState, handleCloseModal, handleLoginState } =
     useModalStore();
 
   const handleClickInquire = () => {
@@ -126,7 +126,7 @@ export default function Search() {
       handleConfirm: () => {
         if (!isLoggedIn) {
           handleCloseModal();
-          handleLoginModal();
+          handleLoginState(true, ROUTES.INQUIRE.REGISTER);
           return;
         }
         handleCloseModal();

--- a/src/components/domain/auth/LoginModal.test.tsx
+++ b/src/components/domain/auth/LoginModal.test.tsx
@@ -1,0 +1,67 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen } from '@testing-library/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { LOGIN_RETURN_TO_KEY } from '@/utils/loginRedirect';
+import LoginModal from './LoginModal';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('@/components/ui/Modal/BackDrop', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const mockUsePathname = usePathname as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
+const mockUseSearchParams = useSearchParams as jest.Mock;
+const mockPush = jest.fn();
+
+describe('LoginModal returnTo 사용자 시나리오', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    mockUseRouter.mockReturnValue({ push: mockPush });
+    mockUsePathname.mockReturnValue('/explore');
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams(
+        'tab=EXPLORER_WHISKEY&keywords=macallan&regionIds=12',
+      ),
+    );
+  });
+
+  it('일반 로그인은 현재 pathname과 search params 전체를 복귀 경로로 저장한다', () => {
+    const handleClose = jest.fn();
+
+    render(<LoginModal handleClose={handleClose} />);
+
+    screen.getByRole('button', { name: '로그인' }).click();
+
+    expect(sessionStorage.getItem(LOGIN_RETURN_TO_KEY)).toBe(
+      '/explore?tab=EXPLORER_WHISKEY&keywords=macallan&regionIds=12',
+    );
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/login');
+  });
+
+  it('명시적인 returnTo가 있으면 현재 URL보다 해당 경로를 우선 저장한다', () => {
+    const handleClose = jest.fn();
+
+    render(
+      <LoginModal handleClose={handleClose} returnTo="/inquire/register" />,
+    );
+
+    screen.getByRole('button', { name: '로그인' }).click();
+
+    expect(sessionStorage.getItem(LOGIN_RETURN_TO_KEY)).toBe(
+      '/inquire/register',
+    );
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/login');
+  });
+});

--- a/src/components/domain/auth/LoginModal.tsx
+++ b/src/components/domain/auth/LoginModal.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Button from '@/components/ui/Button/Button';
 import { ROUTES } from '@/constants/routes';
 import BackDrop from '@/components/ui/Modal/BackDrop';
@@ -10,15 +10,20 @@ import { setReturnToUrl } from '@/utils/loginRedirect';
 
 interface Props {
   handleClose: () => void;
+  returnTo?: string;
 }
 
-function LoginModal({ handleClose }: Props) {
+function LoginModal({ handleClose, returnTo }: Props) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   const handleLoginClick = () => {
+    const queryString = searchParams.toString();
+    const currentUrl = `${pathname}${queryString ? `?${queryString}` : ''}`;
+
     handleClose();
-    setReturnToUrl(pathname);
+    setReturnToUrl(returnTo ?? currentUrl);
     router.push(ROUTES.LOGIN);
   };
 

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -14,6 +14,7 @@ interface ModalState {
 
 interface LoginModalState {
   isShowLoginModal: boolean;
+  returnTo?: string;
 }
 
 export type ParcialModalState = {
@@ -24,7 +25,7 @@ interface ModalStore {
   state: ModalState;
   loginState: LoginModalState;
   handleModalState: (state: ParcialModalState) => void;
-  handleLoginState: (state: boolean) => void;
+  handleLoginState: (state: boolean, returnTo?: string) => void;
   handleCloseModal: () => void;
   handleLoginModal: () => void;
 }
@@ -44,8 +45,13 @@ const useModalStore = create<ModalStore>((set) => ({
   loginState: {
     isShowLoginModal: false,
   },
-  handleLoginState: (newState) =>
-    set({ loginState: { isShowLoginModal: newState } }),
+  handleLoginState: (newState, returnTo) =>
+    set({
+      loginState: {
+        isShowLoginModal: newState,
+        returnTo: newState ? returnTo : undefined,
+      },
+    }),
   handleModalState: (newState) =>
     set((state) => ({
       state: {
@@ -71,8 +77,8 @@ const useModalStore = create<ModalStore>((set) => ({
   handleLoginModal: () =>
     set((state) => ({
       loginState: {
-        ...state.loginState,
         isShowLoginModal: !state.loginState.isShowLoginModal,
+        returnTo: undefined,
       },
     })),
 }));


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

- N/A

## PR 타입 (Type of Change)

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 리팩토링
- [ ] 💄 style: UI/스타일 변경
- [ ] 📝 docs: 문서 수정
- [ ] 🔧 chore: 설정/빌드 변경
- [x] 🧪 test: 테스트 추가/수정

## 변경 사항 (Changes)

- 위스키 둘러보기 검색 결과가 없거나 마지막 페이지에 도달했을 때 위스키 추가 문의 버튼을 노출합니다.
- 일반 로그인 모달은 현재 pathname과 search params를 모두 보존하고, 명시적인 `returnTo`가 있으면 해당 경로를 우선 사용합니다.
- 위스키 추가 문의에서 로그인하면 문의 등록 페이지로 바로 이동하도록 기존 검색 및 둘러보기 경로를 연결했습니다.
- 버튼 노출 조건, 비로그인 문의 연결 및 로그인 모달 return-to 사용자 시나리오 테스트를 추가했습니다.

## 변경 이유 (Reason for Changes)

- 위스키 둘러보기에서도 문의 진입점을 제공하고, 로그인 과정에서 검색 조건이나 사용자가 진행하려던 문의 흐름이 유실되지 않도록 변경했습니다.

## 스크린샷 (Screenshots)

| Before | After |
|--------|-------|
| 미첨부 | 미첨부 |

## 테스트 방법 (Test Procedure)

1. `pnpm exec jest --runInBand --runTestsByPath 'src/app/(primary)/explore/_components/WhiskeyExploreList.test.tsx'`
2. `pnpm exec tsc --noEmit`
3. `pnpm lint`

## 셀프 체크리스트 (Self Checklist)

- [x] 로컬에서 정상 동작 확인
- [x] `pnpm lint` 통과
- [x] 불필요한 console.log 제거
- [x] 반응형/모바일 대응 확인 (UI 변경 시)

## 참고 사항 (Additional Information)

- 기존 `PrimaryLinkButton` 디자인과 위스키 추가 요청 확인 모달을 재사용합니다.
