### PR TITLE
[Product/FE] 큐레이션 프로그램 상세 페이지 QA 수정

### DIFF
--- a/src/api/curation-v2/schema.ts
+++ b/src/api/curation-v2/schema.ts
@@ -75,6 +75,8 @@ export const programFeedPayloadSchema = z.object({
 });
 
 const programScheduleSchema = programFeedItemSchema.extend({
+  programDate: z.string().nullish(),
+  startTime: z.string().nullish(),
   endTime: z.string().nullish(),
   venue: z.string().nullish(),
   host: z.string().nullish(),
@@ -95,7 +97,7 @@ export const programPayloadSchema = z.object({
   officialUrl: z.string().nullish(),
   registrationUrl: z.string().nullish(),
   programTags: z.array(programTagSchema).optional(),
-  programs: z.array(programScheduleSchema).min(1),
+  programs: z.array(programScheduleSchema),
 });
 
 export type CurationAlcohol = z.infer<typeof curationAlcoholSchema>;

--- a/src/app/(primary)/curation/[id]/_components/ProgramDetail.tsx
+++ b/src/app/(primary)/curation/[id]/_components/ProgramDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { ChevronRight, ExternalLink } from 'lucide-react';
 import type { ProgramDetailItem } from '@/api/curation-v2/types';
 import BaseImage from '@/components/ui/Display/BaseImage';
 import {
@@ -51,7 +52,7 @@ export function ProgramDetail({ program }: ProgramDetailProps) {
   return (
     <div
       className={`min-h-safe-screen bg-bg-layer-default text-fg-neutral ${
-        registrationUrl ? 'pb-28' : 'pb-8'
+        registrationUrl ? 'pb-[var(--sticky-cta-space)]' : 'pb-8'
       }`}
     >
       <CurationDetailHeader title={program.name} onBack={() => router.back()} />
@@ -92,9 +93,13 @@ export function ProgramDetail({ program }: ProgramDetailProps) {
             href={officialUrl}
             target="_blank"
             rel="noreferrer"
-            className="mt-5 inline-flex h-10 items-center rounded-lg border border-stroke-brand-solid px-4 text-13 font-bold text-fg-brand"
+            className="mt-5 flex w-full items-center justify-between py-2 text-14 font-bold text-fg-brand"
           >
-            공식 페이지 보기
+            <span className="flex items-center gap-2">
+              <ExternalLink size={16} aria-hidden />
+              공식 페이지 보기
+            </span>
+            <ChevronRight size={16} aria-hidden />
           </a>
         )}
       </section>
@@ -155,23 +160,27 @@ export function ProgramDetail({ program }: ProgramDetailProps) {
         </section>
       )}
 
-      <section className="px-5 py-7">
-        <h2 className="text-16 font-extrabold text-fg-neutral">
-          프로그램 일정
-        </h2>
-        <div className="mt-4">
-          {payload.programs.map((item, index) => (
-            <ProgramScheduleItem
-              key={`${item.name}-${item.programDate}-${item.startTime}`}
-              program={item}
-              order={index + 1}
-            />
-          ))}
-        </div>
-      </section>
+      {payload.programs.length > 0 && (
+        <section className="px-5 py-7">
+          <h2 className="text-16 font-extrabold text-fg-neutral">
+            프로그램 및 이벤트 라인업
+          </h2>
+          <div className="mt-4 space-y-4">
+            {payload.programs.map((item, index) => (
+              <ProgramScheduleItem
+                key={`${item.name}-${index}`}
+                program={item}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
       {registrationUrl && (
-        <div className="fixed-content bottom-7 z-20 px-5">
+        <div
+          className="fixed-content z-20 px-5"
+          style={{ bottom: 'var(--navbar-margin-bottom)' }}
+        >
           <a
             href={registrationUrl}
             target="_blank"
@@ -179,7 +188,7 @@ export function ProgramDetail({ program }: ProgramDetailProps) {
             className="flex h-[52px] w-full items-center justify-center rounded-xl bg-bg-brand-solid active:bg-bg-brand-solid-pressed"
           >
             <span className="text-15 font-bold text-fg-brand-contrast">
-              행사 신청하기
+              행사 참가 신청
             </span>
           </a>
         </div>

--- a/src/app/(primary)/curation/[id]/page.tsx
+++ b/src/app/(primary)/curation/[id]/page.tsx
@@ -69,7 +69,7 @@ function TastingEventDetail({ event }: { event: TastingEventDetailItem }) {
   return (
     <div
       className={`min-h-safe-screen bg-bg-layer-default text-fg-neutral ${
-        shouldShowCta ? 'pb-28' : 'pb-8'
+        shouldShowCta ? 'pb-[var(--sticky-cta-space)]' : 'pb-8'
       }`}
     >
       <CurationDetailHeader title={event.name} onBack={() => router.back()} />
@@ -181,7 +181,10 @@ function TastingEventDetail({ event }: { event: TastingEventDetailItem }) {
       )}
 
       {shouldShowCta && (
-        <div className="fixed-content bottom-7 z-20 px-5">
+        <div
+          className="fixed-content z-20 px-5"
+          style={{ bottom: 'var(--navbar-margin-bottom)' }}
+        >
           {canApply ? (
             <a
               href={applicationLink}

--- a/src/app/(primary)/curation/_components/ProgramEventInfoCard.tsx
+++ b/src/app/(primary)/curation/_components/ProgramEventInfoCard.tsx
@@ -1,4 +1,4 @@
-import { Building2, Calendar, MapPin, Ticket } from 'lucide-react';
+import { Building2, Calendar, MapPin, Users } from 'lucide-react';
 import type { ProgramPayload } from '@/api/curation-v2/types';
 import { cn } from '@/lib/utils';
 import {
@@ -15,8 +15,7 @@ interface ProgramEventInfoCardProps {
 interface ProgramEventInfoItem {
   key: string;
   Icon: typeof Calendar;
-  label: string;
-  value: string;
+  title: string;
   action?: {
     href: string;
     label: string;
@@ -43,8 +42,7 @@ export function ProgramEventInfoCard({
     {
       key: 'date',
       Icon: Calendar,
-      label: '행사 기간',
-      value: formatProgramDateRange(
+      title: formatProgramDateRange(
         payload.eventStartDate,
         payload.eventEndDate,
       ),
@@ -52,8 +50,7 @@ export function ProgramEventInfoCard({
     {
       key: 'place',
       Icon: MapPin,
-      label: payload.placeName,
-      value: fullAddress,
+      title: fullAddress,
       action: mapSearchUrl
         ? {
             href: mapSearchUrl,
@@ -66,16 +63,14 @@ export function ProgramEventInfoCard({
           {
             key: 'organizer',
             Icon: Building2,
-            label: '주최 / 주관',
-            value: organizerText,
+            title: organizerText,
           },
         ]
       : []),
     {
-      key: 'fee',
-      Icon: Ticket,
-      label: '참가비',
-      value: entryFeeLabel,
+      key: 'programs',
+      Icon: Users,
+      title: `프로그램 ${payload.programs.length}개`,
     },
   ];
 
@@ -86,34 +81,38 @@ export function ProgramEventInfoCard({
         className,
       )}
     >
-      <div className="flex flex-col gap-4">
-        {infoItems.map(({ key, Icon, label, value, action }) => (
+      <div className="flex flex-col gap-6">
+        {infoItems.map(({ key, Icon, title, action }) => (
           <div key={key} className="flex gap-2.5">
             <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center text-fg-neutral">
               <Icon size={16} strokeWidth={2} />
             </span>
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 items-start justify-between gap-2">
-                <p className="min-w-0 flex-1 break-words text-14 font-bold leading-[18px] text-fg-neutral">
-                  {label}
-                </p>
-                {action && (
-                  <a
-                    href={action.href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="shrink-0 rounded-md bg-bg-layer-default px-3 py-1 text-13 font-bold leading-[17px] text-fg-neutral"
-                  >
-                    {action.label}
-                  </a>
-                )}
-              </div>
-              <p className="mt-1 break-words text-13 font-light leading-[17px] text-fg-neutral-muted">
-                {value}
+            <div className="flex min-w-0 flex-1 items-start justify-between gap-2">
+              <p className="min-w-0 flex-1 break-words text-14 font-bold leading-[18px] text-fg-neutral">
+                {title}
               </p>
+              {action && (
+                <a
+                  href={action.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="shrink-0 rounded-md bg-bg-layer-default px-3 py-1 text-13 font-bold leading-[17px] text-fg-neutral"
+                >
+                  {action.label}
+                </a>
+              )}
             </div>
           </div>
         ))}
+
+        <div className="flex items-end justify-between gap-2 border-t border-stroke-neutral-basement pt-4">
+          <span className="text-13 font-semibold leading-[17px] text-fg-neutral">
+            참가비
+          </span>
+          <span className="text-right text-[19px] font-bold leading-none text-fg-neutral">
+            {entryFeeLabel}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(primary)/curation/_components/ProgramScheduleItem.tsx
+++ b/src/app/(primary)/curation/_components/ProgramScheduleItem.tsx
@@ -1,4 +1,9 @@
-import { CalendarClock, MapPin, UserRound } from 'lucide-react';
+import {
+  CalendarClock,
+  Link as LinkIcon,
+  MapPin,
+  UserRound,
+} from 'lucide-react';
 import type { ProgramSchedule } from '@/api/curation-v2/types';
 import { TastingEventLineupItem } from '@/app/(primary)/curation/_components/TastingEventLineupItem';
 import {
@@ -9,88 +14,85 @@ import {
 
 interface ProgramScheduleItemProps {
   program: ProgramSchedule;
-  order: number;
 }
 
-export function ProgramScheduleItem({
-  program,
-  order,
-}: ProgramScheduleItemProps) {
-  const dateTime = `${formatProgramDate(program.programDate)} · ${formatProgramTime(
-    program.startTime,
-    program.endTime,
-  )}`;
+export function ProgramScheduleItem({ program }: ProgramScheduleItemProps) {
+  const dateTime = [
+    program.programDate && formatProgramDate(program.programDate),
+    program.startTime && formatProgramTime(program.startTime, program.endTime),
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
-    <article className="border-b border-stroke-neutral-basement py-6 first:pt-0 last:border-b-0 last:pb-0">
-      <div className="flex items-start gap-3">
-        <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-neutral-solid text-11 font-bold text-fg-neutral-inverted">
-          {order}
-        </span>
-        <div className="min-w-0 flex-1">
-          <span className="inline-flex rounded-full bg-bg-brand-weak px-2 py-1 text-11 font-bold text-fg-brand">
-            {formatProgramType(program.type)}
-          </span>
-          <h3 className="mt-2 text-16 font-extrabold leading-5 text-fg-neutral">
-            {program.name}
-          </h3>
+    <article className="rounded-xl border border-stroke-neutral-subtle p-4">
+      <span className="inline-flex rounded-full bg-bg-brand-weak px-2 py-1 text-11 font-bold text-fg-brand">
+        {formatProgramType(program.type)}
+      </span>
+      <h3 className="mt-2 text-16 font-extrabold leading-5 text-fg-neutral">
+        {program.name}
+      </h3>
 
-          <div className="mt-3 space-y-2 text-13 font-medium leading-[17px] text-fg-neutral-muted">
-            <p className="flex gap-2">
-              <CalendarClock size={16} className="shrink-0" aria-hidden />
-              <span>{dateTime}</span>
-            </p>
-            {program.venue && (
-              <p className="flex gap-2">
-                <MapPin size={16} className="shrink-0" aria-hidden />
-                <span>{program.venue}</span>
-              </p>
-            )}
-            {program.host && (
-              <p className="flex gap-2">
-                <UserRound size={16} className="shrink-0" aria-hidden />
-                <span>{program.host}</span>
-              </p>
-            )}
-          </div>
-
-          <p className="mt-4 whitespace-pre-line text-13 font-medium leading-[1.7] text-fg-neutral">
-            {program.description}
+      <div className="mt-3 space-y-2 text-13 font-medium leading-[17px] text-fg-neutral-muted">
+        {program.venue && (
+          <p className="flex gap-2">
+            <MapPin size={16} className="shrink-0" aria-hidden />
+            <span>{program.venue}</span>
           </p>
-
-          {program.applicationUrl && (
-            <a
-              href={program.applicationUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="mt-4 inline-flex h-9 items-center rounded-lg border border-stroke-brand-solid px-3 text-13 font-bold text-fg-brand"
-            >
-              프로그램 신청하기
-            </a>
-          )}
-
-          {program.whiskies && program.whiskies.length > 0 && (
-            <section className="mt-6">
-              <h4 className="text-14 font-extrabold text-fg-neutral">
-                시음 위스키
-              </h4>
-              <div className="mt-3 divide-y divide-stroke-neutral-basement border-t border-stroke-neutral-basement">
-                {program.whiskies.map((whisky, index) => (
-                  <TastingEventLineupItem
-                    key={
-                      whisky.alcohol.alcoholId != null
-                        ? `alcohol-${whisky.alcohol.alcoholId}`
-                        : `manual-${whisky.alcohol.korName}-${whisky.alcohol.engName ?? ''}`
-                    }
-                    item={whisky}
-                    order={index + 1}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
+        )}
+        {program.host && (
+          <p className="flex gap-2">
+            <UserRound size={16} className="shrink-0" aria-hidden />
+            <span>{program.host}</span>
+          </p>
+        )}
+        {program.applicationUrl && (
+          <a
+            href={program.applicationUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex gap-2 font-bold text-fg-brand"
+          >
+            <LinkIcon size={16} className="shrink-0" aria-hidden />
+            <span className="break-all">
+              안내 링크 : {program.applicationUrl}
+            </span>
+          </a>
+        )}
+        {dateTime && (
+          <p className="flex gap-2">
+            <CalendarClock size={16} className="shrink-0" aria-hidden />
+            <span>{dateTime}</span>
+          </p>
+        )}
       </div>
+
+      {program.description && (
+        <p className="mt-4 whitespace-pre-line text-13 font-medium leading-[1.7] text-fg-neutral">
+          {program.description}
+        </p>
+      )}
+
+      {program.whiskies && program.whiskies.length > 0 && (
+        <section className="mt-6">
+          <h4 className="text-14 font-extrabold text-fg-neutral">
+            시음 위스키
+          </h4>
+          <div className="mt-3 divide-y divide-stroke-neutral-basement border-t border-stroke-neutral-basement">
+            {program.whiskies.map((whisky, index) => (
+              <TastingEventLineupItem
+                key={
+                  whisky.alcohol.alcoholId != null
+                    ? `alcohol-${whisky.alcohol.alcoholId}`
+                    : `manual-${whisky.alcohol.korName}-${whisky.alcohol.engName ?? ''}`
+                }
+                item={whisky}
+                order={index + 1}
+              />
+            ))}
+          </div>
+        </section>
+      )}
     </article>
   );
 }

--- a/src/app/(primary)/curation/_components/TastingEventInfoCard.tsx
+++ b/src/app/(primary)/curation/_components/TastingEventInfoCard.tsx
@@ -86,7 +86,13 @@ export function TastingEventInfoCard({
         </span>
       )}
 
-      <div className={cn('flex h-full flex-col gap-4', label && 'mt-2')}>
+      <div
+        className={cn(
+          'flex h-full flex-col',
+          shouldWrapText ? 'gap-6' : 'gap-4',
+          label && 'mt-2',
+        )}
+      >
         {infoItems.map(({ key, Icon, title, description, action }) => (
           <div key={key} className="flex gap-2.5">
             <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center text-fg-neutral">
@@ -129,7 +135,7 @@ export function TastingEventInfoCard({
           </div>
         ))}
 
-        <div className="mt-auto flex items-end gap-2">
+        <div className="mt-auto flex items-end justify-between gap-2 border-t border-stroke-neutral-basement pt-4">
           <span
             className={`font-semibold text-fg-neutral ${
               shouldWrapText
@@ -139,7 +145,7 @@ export function TastingEventInfoCard({
           >
             참가비
           </span>
-          <span className="text-[19px] font-bold leading-none text-fg-neutral">
+          <span className="text-right text-[19px] font-bold leading-none text-fg-neutral">
             {tastingEvent.entryFeeLabel}
           </span>
         </div>

--- a/src/app/(primary)/curation/_components/TastingEventLineupItem.tsx
+++ b/src/app/(primary)/curation/_components/TastingEventLineupItem.tsx
@@ -67,7 +67,7 @@ export function TastingEventLineupItem({
           </div>
 
           {isDetailAvailable && (
-            <div className="shrink-0 pt-0.5">
+            <div className="shrink-0">
               <span className="link-button">상세보기 &gt;</span>
             </div>
           )}

--- a/src/app/(primary)/curation/_components/TastingEventLineupItem.tsx
+++ b/src/app/(primary)/curation/_components/TastingEventLineupItem.tsx
@@ -23,7 +23,11 @@ export function TastingEventLineupItem({
   const isDetailAvailable = alcoholId != null;
   const content = (
     <>
-      <div className="absolute left-0 top-6 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-bg-neutral-solid text-10 font-bold text-fg-neutral-inverted">
+      <div
+        className={`absolute left-0 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-bg-neutral-solid text-10 font-bold text-fg-neutral-inverted ${
+          chips.length > 0 ? 'top-6' : 'top-3'
+        }`}
+      >
         {order}
       </div>
 
@@ -34,7 +38,7 @@ export function TastingEventLineupItem({
           className="h-[128px] w-[95px]"
         />
 
-        <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-baseline justify-between gap-3">
           <div className="min-w-0 flex-1 space-y-2">
             <ItemInfo
               korName={alcohol.korName}
@@ -67,15 +71,13 @@ export function TastingEventLineupItem({
           </div>
 
           {isDetailAvailable && (
-            <div className="shrink-0">
-              <span className="link-button">상세보기 &gt;</span>
-            </div>
+            <span className="link-button shrink-0">상세보기 &gt;</span>
           )}
         </div>
       </div>
 
       {chips.length > 0 && (
-        <div className="mt-5 flex w-full flex-wrap gap-1.5">
+        <div className="mt-2 flex w-full flex-wrap gap-1.5">
           {chips.map((chip) => (
             <span
               key={chip}
@@ -96,7 +98,7 @@ export function TastingEventLineupItem({
   );
 
   return (
-    <article className="relative py-6">
+    <article className={`relative ${chips.length > 0 ? 'py-6' : 'py-3'}`}>
       {isDetailAvailable ? (
         <Link
           href={ROUTES.SEARCH.ALL(alcoholId)}


### PR DESCRIPTION
## 작업 내용

- 프로그램 상세 정보카드의 행사 기간, 주소, 주최 정보, 프로그램 수, 참가비 위계를 정리했습니다.
- 프로그램 및 이벤트 라인업을 카드 형태로 변경하고, 비어 있는 일정·시간·링크는 노출하지 않도록 조정했습니다.
- 행사 공식 페이지와 참가 신청 CTA를 구분하고 하단 CTA의 safe area를 맞췄습니다.
- 시음회 정보카드의 상세 간격과 참가비 영역을 프로그램 정보카드와 동일한 구조로 조정했습니다.
- 위스키 라인업의 테이스팅 태그 간격과 태그가 없는 항목의 여백을 줄이고, 상세보기 링크를 첫 번째 텍스트 라인의 baseline에 맞췄습니다.

## 확인

- 실제 PROGRAM 상세 데이터로 로컬 화면을 수동 확인했습니다.
- 커밋 훅의 ESLint 및 Prettier를 통과했습니다.
- 요청에 따라 자동화 테스트는 실행하지 않았습니다.

## 원본 이슈

- Closes bottle-note/workspace#350
- https://github.com/bottle-note/workspace/issues/350