### PR TITLE
[Product/FE] 페어링 큐레이션 탭 추가

### DIFF
--- a/src/__tests__/components/WhiskyPairingDetail.test.tsx
+++ b/src/__tests__/components/WhiskyPairingDetail.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import type { WhiskyPairingDetailItem } from '@/api/curation-v2/types';
+import { WhiskyPairingDetail } from '@/app/(primary)/curation/[id]/_components/WhiskyPairingDetail';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+class ResizeObserverMock {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock;
+
+const pairing: WhiskyPairingDetailItem = {
+  id: 18,
+  name: '위스키와 잘 어울리는 디저트',
+  description: '무더운 여름 위스키와 잘 어울리는 디저트를 소개합니다.',
+  coverImageUrl: 'https://example.com/cover.jpg',
+  imageUrls: [],
+  exposureStartDate: '2026-07-01',
+  exposureEndDate: '2026-08-01',
+  displayOrder: 1,
+  createAt: '2026-07-01',
+  spec: {
+    id: 2,
+    code: 'WHISKY_PAIRING',
+    name: '위스키 페어링',
+    container: 'array',
+    responseSpec: {},
+  },
+  payload: [
+    {
+      source: 'BOTTLE_NOTE',
+      alcohol: {
+        alcoholId: 6415,
+        korName: 'TSC 2013 글렌오드 8년',
+      },
+      pairings: [
+        {
+          itemName: '솔티드 초콜릿',
+          pairingNote: '짠맛이 위스키의 단맛을 살려줘요.',
+          itemImageUrl: 'https://example.com/chocolate.jpg',
+        },
+        {
+          itemName: '바닐라 아이스크림',
+          pairingNote: '부드러운 질감이 위스키의 여운과 이어져요.',
+        },
+      ],
+    },
+  ],
+};
+
+describe('WhiskyPairingDetail', () => {
+  it('Figma의 페어링 라인업 구조로 음식과 설명을 렌더링한다', () => {
+    render(<WhiskyPairingDetail pairing={pairing} />);
+
+    expect(screen.getByText('페어링 2종 추천')).toBeInTheDocument();
+    expect(screen.getByText('페어링 라인업')).toBeInTheDocument();
+    expect(screen.getByText('TSC 2013 글렌오드 8년')).toBeInTheDocument();
+    expect(screen.getByText('솔티드 초콜릿')).toBeInTheDocument();
+    expect(
+      screen.getByText('짠맛이 위스키의 단맛을 살려줘요.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('바닐라 아이스크림')).toBeInTheDocument();
+
+    expect(screen.getByText('페어링 1')).toHaveClass(
+      'bg-bg-brand-weak',
+      'text-fg-brand',
+    );
+  });
+});

--- a/src/api/curation-v2/guards.ts
+++ b/src/api/curation-v2/guards.ts
@@ -3,15 +3,19 @@ import {
   programPayloadSchema,
   recommendedWhiskyPayloadSchema,
   tastingEventPayloadSchema,
+  whiskyPairingPayloadSchema,
 } from './schema';
 import type {
   CurationV2DetailItem,
   CurationV2FeedItem,
   ProgramDetailItem,
   ProgramFeedItem,
-  RecommendedWhiskyFeedItem,
+  RecommendedWhiskyDetailItem,
   TastingEventFeedItem,
+  WhiskyPairingDetailItem,
+  WhiskyPairingFeedItem,
 } from './types';
+import { CURATION_V2_SPEC_CODES } from './constants';
 
 export const isTastingEventFeedItem = (
   item: CurationV2FeedItem,
@@ -28,7 +32,19 @@ export const isProgramDetailItem = (
 ): item is ProgramDetailItem =>
   programPayloadSchema.safeParse(item.payload).success;
 
-export const isRecommendedWhiskyFeedItem = (
-  item: CurationV2FeedItem,
-): item is RecommendedWhiskyFeedItem =>
+export const isRecommendedWhiskyDetailItem = (
+  item: CurationV2DetailItem,
+): item is RecommendedWhiskyDetailItem =>
+  item.spec?.code === CURATION_V2_SPEC_CODES.RECOMMENDED_WHISKY &&
   recommendedWhiskyPayloadSchema.safeParse(item.payload).success;
+
+export const isWhiskyPairingFeedItem = (
+  item: CurationV2FeedItem,
+): item is WhiskyPairingFeedItem =>
+  whiskyPairingPayloadSchema.safeParse(item.payload).success;
+
+export const isWhiskyPairingDetailItem = (
+  item: CurationV2DetailItem,
+): item is WhiskyPairingDetailItem =>
+  item.spec?.code === CURATION_V2_SPEC_CODES.WHISKY_PAIRING &&
+  whiskyPairingPayloadSchema.safeParse(item.payload).success;

--- a/src/api/curation-v2/schema.test.ts
+++ b/src/api/curation-v2/schema.test.ts
@@ -1,5 +1,15 @@
-import { isProgramDetailItem, isProgramFeedItem } from './guards';
-import { programFeedPayloadSchema, programPayloadSchema } from './schema';
+import {
+  isProgramDetailItem,
+  isProgramFeedItem,
+  isRecommendedWhiskyDetailItem,
+  isWhiskyPairingDetailItem,
+  isWhiskyPairingFeedItem,
+} from './guards';
+import {
+  programFeedPayloadSchema,
+  programPayloadSchema,
+  whiskyPairingPayloadSchema,
+} from './schema';
 import type { CurationV2DetailItem, CurationV2FeedItem } from './types';
 
 const programFeedPayload = {
@@ -75,5 +85,83 @@ describe('PROGRAM payload contract', () => {
 
     expect(programPayloadSchema.safeParse(programPayload).success).toBe(true);
     expect(isProgramDetailItem(detailItem)).toBe(true);
+  });
+});
+
+describe('WHISKY_PAIRING payload contract', () => {
+  const pairingPayload = [
+    {
+      source: 'BOTTLE_NOTE',
+      alcohol: {
+        alcoholId: 6415,
+        korName: 'TSC 2013 글렌오드 8년',
+        selectedTags: ['셰리', '초콜릿'],
+      },
+      comment: '달콤한 디저트와 잘 어울려요.',
+      pairings: [
+        {
+          itemName: '솔티드 초콜릿',
+          pairingNote: '짠맛이 위스키의 단맛을 살려줘요.',
+          itemImageUrl: 'https://example.com/chocolate.jpg',
+        },
+      ],
+    },
+  ];
+
+  const pairingFeedItem: CurationV2FeedItem = {
+    ...feedItem,
+    id: 18,
+    name: '위스키와 잘 어울리는 디저트',
+    payload: pairingPayload,
+  };
+
+  it('페어링 음식 목록을 포함한 payload를 판별한다', () => {
+    expect(whiskyPairingPayloadSchema.safeParse(pairingPayload).success).toBe(
+      true,
+    );
+    expect(isWhiskyPairingFeedItem(pairingFeedItem)).toBe(true);
+  });
+
+  it('상세 응답은 WHISKY_PAIRING spec code까지 확인한다', () => {
+    const detailItem: CurationV2DetailItem = {
+      ...pairingFeedItem,
+      spec: {
+        id: 2,
+        code: 'WHISKY_PAIRING',
+        name: '위스키 페어링',
+        container: 'array',
+        responseSpec: {},
+      },
+    };
+
+    expect(isWhiskyPairingDetailItem(detailItem)).toBe(true);
+    expect(isRecommendedWhiskyDetailItem(detailItem)).toBe(false);
+  });
+});
+
+describe('RECOMMENDED_WHISKY detail contract', () => {
+  it('상세 응답은 RECOMMENDED_WHISKY spec code까지 확인한다', () => {
+    const detailItem: CurationV2DetailItem = {
+      ...feedItem,
+      payload: [
+        {
+          source: 'BOTTLE_NOTE',
+          alcohol: {
+            alcoholId: 6415,
+            korName: 'TSC 2013 글렌오드 8년',
+          },
+        },
+      ],
+      spec: {
+        id: 3,
+        code: 'RECOMMENDED_WHISKY',
+        name: '추천 위스키',
+        container: 'array',
+        responseSpec: {},
+      },
+    };
+
+    expect(isRecommendedWhiskyDetailItem(detailItem)).toBe(true);
+    expect(isWhiskyPairingDetailItem(detailItem)).toBe(false);
   });
 });

--- a/src/api/curation-v2/schema.ts
+++ b/src/api/curation-v2/schema.ts
@@ -41,6 +41,18 @@ export const tastingEventPayloadSchema = z.object({
 
 export const recommendedWhiskyPayloadSchema = z.array(curationAlcoholSchema);
 
+export const pairingFoodSchema = z.object({
+  itemName: z.string(),
+  pairingNote: z.string(),
+  itemImageUrl: z.string().optional(),
+});
+
+export const whiskyPairingItemSchema = curationAlcoholSchema.extend({
+  pairings: z.array(pairingFoodSchema).min(1),
+});
+
+export const whiskyPairingPayloadSchema = z.array(whiskyPairingItemSchema);
+
 export const programTypeSchema = z.enum([
   'MASTER_CLASS',
   'TASTING',
@@ -104,6 +116,9 @@ export type CurationAlcohol = z.infer<typeof curationAlcoholSchema>;
 export type RecommendedWhiskyPayload = z.infer<
   typeof recommendedWhiskyPayloadSchema
 >;
+export type PairingFood = z.infer<typeof pairingFoodSchema>;
+export type WhiskyPairingItem = z.infer<typeof whiskyPairingItemSchema>;
+export type WhiskyPairingPayload = z.infer<typeof whiskyPairingPayloadSchema>;
 export type TastingEventAlcohol = CurationAlcohol;
 export type TastingEventPayload = z.infer<typeof tastingEventPayloadSchema>;
 export type ProgramType = z.infer<typeof programTypeSchema>;

--- a/src/api/curation-v2/types.ts
+++ b/src/api/curation-v2/types.ts
@@ -8,6 +8,7 @@ import type {
   ProgramPayload,
   RecommendedWhiskyPayload,
   TastingEventPayload,
+  WhiskyPairingPayload,
 } from './schema';
 
 export type {
@@ -19,9 +20,12 @@ export type {
   ProgramTag,
   ProgramType,
   ProgramWhisky,
+  PairingFood,
   RecommendedWhiskyPayload,
   TastingEventAlcohol,
   TastingEventPayload,
+  WhiskyPairingItem,
+  WhiskyPairingPayload,
 } from './schema';
 
 export type CurationV2Payload =
@@ -29,6 +33,7 @@ export type CurationV2Payload =
   | ProgramPayload
   | RecommendedWhiskyPayload
   | TastingEventPayload
+  | WhiskyPairingPayload
   | Record<string, unknown>
   | null;
 
@@ -78,10 +83,14 @@ export interface ProgramDetailItem extends CurationV2DetailItem {
   payload: ProgramPayload;
 }
 
-export interface RecommendedWhiskyFeedItem extends CurationV2FeedItem {
+export interface RecommendedWhiskyDetailItem extends CurationV2DetailItem {
   payload: RecommendedWhiskyPayload;
 }
 
-export interface RecommendedWhiskyDetailItem extends CurationV2DetailItem {
-  payload: RecommendedWhiskyPayload;
+export interface WhiskyPairingFeedItem extends CurationV2FeedItem {
+  payload: WhiskyPairingPayload;
+}
+
+export interface WhiskyPairingDetailItem extends CurationV2DetailItem {
+  payload: WhiskyPairingPayload;
 }

--- a/src/app/(primary)/curation/[id]/_components/WhiskyPairingDetail.tsx
+++ b/src/app/(primary)/curation/[id]/_components/WhiskyPairingDetail.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { WhiskyPairingDetailItem } from '@/api/curation-v2/types';
+import BaseImage from '@/components/ui/Display/BaseImage';
+import { CurationDetailHeader } from '@/app/(primary)/curation/_components/CurationDetailHeader';
+import { TastingEventLineupItem } from '@/app/(primary)/curation/_components/TastingEventLineupItem';
+import { WhiskyPairingFoodList } from '@/app/(primary)/curation/_components/WhiskyPairingFoodList';
+
+interface WhiskyPairingDetailProps {
+  pairing: WhiskyPairingDetailItem;
+}
+
+export function WhiskyPairingDetail({ pairing }: WhiskyPairingDetailProps) {
+  const router = useRouter();
+  const pairingFoods = pairing.payload.flatMap((item) => item.pairings);
+
+  return (
+    <div className="min-h-safe-screen bg-bg-layer-default pb-8 text-fg-neutral">
+      <CurationDetailHeader title={pairing.name} onBack={() => router.back()} />
+
+      <section className="relative h-60 w-full overflow-hidden bg-bg-neutral-weak">
+        <BaseImage
+          src={pairing.coverImageUrl}
+          alt=""
+          fill
+          priority
+          sizes="(max-width: 468px) 100vw, 468px"
+          className="object-cover"
+        />
+        <div className="absolute inset-0 bg-[#5F3826]/25" />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/10 via-black/20 to-black/75" />
+        <div className="absolute bottom-5 left-5 right-5 text-white">
+          <span className="inline-flex rounded-full bg-bg-brand-solid px-2.5 py-1 text-10 font-bold text-fg-brand-contrast">
+            페어링
+          </span>
+          <h1 className="mt-3 line-clamp-2 text-20 font-extrabold">
+            {pairing.name}
+          </h1>
+          <p className="mt-2 text-13 font-light text-white/85">
+            페어링 {pairingFoods.length}종 추천
+          </p>
+        </div>
+      </section>
+
+      <section className="px-5 py-5">
+        <p className="whitespace-pre-line text-13 font-medium leading-[1.7] text-fg-neutral-muted">
+          {pairing.description}
+        </p>
+      </section>
+
+      {pairing.payload.length > 0 && (
+        <section className="px-5 py-7">
+          <h2 className="text-16 font-extrabold text-fg-neutral">
+            페어링 라인업
+          </h2>
+          <div className="mt-4 space-y-7">
+            {pairing.payload.map((item, index) => (
+              <div
+                key={
+                  item.alcohol.alcoholId != null
+                    ? `alcohol-${item.alcohol.alcoholId}`
+                    : `manual-${item.alcohol.korName}-${index}`
+                }
+              >
+                <TastingEventLineupItem item={item} order={index + 1} />
+                <WhiskyPairingFoodList pairings={item.pairings} />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/(primary)/curation/[id]/page.tsx
+++ b/src/app/(primary)/curation/[id]/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import {
   isProgramDetailItem,
-  isRecommendedWhiskyFeedItem,
+  isRecommendedWhiskyDetailItem,
   isTastingEventFeedItem,
+  isWhiskyPairingDetailItem,
 } from '@/api/curation-v2/guards';
 import type {
   RecommendedWhiskyDetailItem,
@@ -28,6 +29,7 @@ import { TastingEventLineupItem } from '@/app/(primary)/curation/_components/Tas
 import { CurationDetailHeader } from '@/app/(primary)/curation/_components/CurationDetailHeader';
 import { parseTastingEventPayload } from '@/app/(primary)/curation/_utils/parseTastingEventPayload';
 import { ProgramDetail } from './_components/ProgramDetail';
+import { WhiskyPairingDetail } from './_components/WhiskyPairingDetail';
 
 function TastingEventDetail({ event }: { event: TastingEventDetailItem }) {
   const router = useRouter();
@@ -377,8 +379,12 @@ export default function CurationDetailPage() {
     return <ProgramDetail program={data} />;
   }
 
-  if (isRecommendedWhiskyFeedItem(data)) {
-    return <CurationDetail curation={data as RecommendedWhiskyDetailItem} />;
+  if (isWhiskyPairingDetailItem(data)) {
+    return <WhiskyPairingDetail pairing={data} />;
+  }
+
+  if (isRecommendedWhiskyDetailItem(data)) {
+    return <CurationDetail curation={data} />;
   }
 
   return (

--- a/src/app/(primary)/curation/_components/CurationFeedCard.tsx
+++ b/src/app/(primary)/curation/_components/CurationFeedCard.tsx
@@ -3,15 +3,17 @@ import type { CurationV2FeedItem } from '@/api/curation-v2/types';
 import BaseImage from '@/components/ui/Display/BaseImage';
 import { ROUTES } from '@/constants/routes';
 
-interface RecommendedCurationFeedCardProps {
+interface CurationFeedCardProps {
   curation: CurationV2FeedItem;
+  badgeLabel: string;
   priority?: boolean;
 }
 
-export function RecommendedCurationFeedCard({
+export function CurationFeedCard({
   curation,
+  badgeLabel,
   priority = false,
-}: RecommendedCurationFeedCardProps) {
+}: CurationFeedCardProps) {
   return (
     <Link href={ROUTES.CURATION.DETAIL(curation.id)} className="block">
       <article className="relative isolate h-[157px] w-full overflow-hidden rounded-lg bg-bg-neutral-weak">
@@ -31,7 +33,7 @@ export function RecommendedCurationFeedCard({
 
         <div className="relative z-10 flex h-full flex-col px-4 pb-4 pt-4">
           <span className="inline-flex w-fit rounded-full bg-white/30 px-2.5 py-1 text-11 font-bold text-white backdrop-blur-sm">
-            큐레이션
+            {badgeLabel}
           </span>
           <h2 className="mt-4 line-clamp-2 text-[22px] font-extrabold leading-[26px] text-white">
             {curation.name}

--- a/src/app/(primary)/curation/_components/WhiskyPairingFoodList.tsx
+++ b/src/app/(primary)/curation/_components/WhiskyPairingFoodList.tsx
@@ -1,0 +1,48 @@
+import type { PairingFood } from '@/api/curation-v2/types';
+import BaseImage from '@/components/ui/Display/BaseImage';
+
+interface WhiskyPairingFoodListProps {
+  pairings: PairingFood[];
+}
+
+export function WhiskyPairingFoodList({
+  pairings,
+}: WhiskyPairingFoodListProps) {
+  if (pairings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl bg-bg-neutral-weak px-4">
+      {pairings.map((food, index) => (
+        <article
+          key={`${food.itemName}-${food.itemImageUrl ?? index}`}
+          className="border-b border-stroke-neutral-basement py-4 last:border-b-0"
+        >
+          <span className="inline-flex rounded-full bg-bg-brand-weak px-2 py-1 text-10 font-bold text-fg-brand">
+            페어링 {index + 1}
+          </span>
+          <div className="mt-2 flex items-start gap-3">
+            <div className="h-[60px] w-[60px] shrink-0 overflow-hidden rounded-lg bg-bg-layer-default">
+              <BaseImage
+                src={food.itemImageUrl ?? ''}
+                alt={food.itemName}
+                width={60}
+                height={60}
+                className="object-cover"
+              />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-13 font-extrabold leading-5 text-fg-neutral">
+                {food.itemName}
+              </h3>
+              <p className="mt-1 whitespace-pre-line break-words text-12 font-medium leading-[1.6] text-fg-neutral-muted">
+                {food.pairingNote}
+              </p>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(primary)/curation/page.tsx
+++ b/src/app/(primary)/curation/page.tsx
@@ -8,21 +8,26 @@ import { useTab } from '@/hooks/useTab';
 import { useCurationsQuery } from '@/queries/useCurationsQuery';
 import { useProgramsQuery } from '@/queries/useProgramsQuery';
 import { useTastingEventsQuery } from '@/queries/useTastingEventsQuery';
+import { useWhiskyPairingsQuery } from '@/queries/useWhiskyPairingsQuery';
 import UnderlineSearchBar from '@/components/feature/Search/UnderlineSearchBar';
 import Tab from '@/components/ui/Navigation/Tab';
 import { SubHeader } from '@/components/ui/Navigation/SubHeader';
+import { CurationFeedCard } from './_components/CurationFeedCard';
 import { ProgramFeedCard } from './_components/ProgramFeedCard';
-import { RecommendedCurationFeedCard } from './_components/RecommendedCurationFeedCard';
 import { TastingEventFeedCard } from './_components/TastingEventFeedCard';
 
 type CurationTabId =
   | typeof CURATION_V2_SPEC_CODES.WHISKY_TASTING_EVENT
   | typeof CURATION_V2_SPEC_CODES.PROGRAM
+  | typeof CURATION_V2_SPEC_CODES.WHISKY_PAIRING
   | typeof CURATION_V2_SPEC_CODES.RECOMMENDED_WHISKY;
 
+// Product가 전용 렌더러를 제공하는 스펙만 고정 노출합니다. 데이터가 없는
+// 스펙도 탭과 빈 상태를 유지하며, 새 스펙은 렌더러와 함께 명시적으로 추가합니다.
 const tabList = [
   { name: '시음회', id: CURATION_V2_SPEC_CODES.WHISKY_TASTING_EVENT },
   { name: '프로그램', id: CURATION_V2_SPEC_CODES.PROGRAM },
+  { name: '페어링', id: CURATION_V2_SPEC_CODES.WHISKY_PAIRING },
   { name: '큐레이션', id: CURATION_V2_SPEC_CODES.RECOMMENDED_WHISKY },
 ] satisfies { name: string; id: CurationTabId }[];
 
@@ -79,7 +84,9 @@ export default function CurationPage() {
   const isTastingEventTab =
     currentTab.id === CURATION_V2_SPEC_CODES.WHISKY_TASTING_EVENT;
   const isProgramTab = currentTab.id === CURATION_V2_SPEC_CODES.PROGRAM;
-  const isRecommendedTab = !isTastingEventTab && !isProgramTab;
+  const isPairingTab = currentTab.id === CURATION_V2_SPEC_CODES.WHISKY_PAIRING;
+  const isRecommendedTab =
+    currentTab.id === CURATION_V2_SPEC_CODES.RECOMMENDED_WHISKY;
   const curationsQuery = useCurationsQuery(
     10,
     trimmedSearchKeyword,
@@ -92,39 +99,103 @@ export default function CurationPage() {
     CURATION_V2_SPEC_CODES.PROGRAM,
     isProgramTab,
   );
+  const pairingsQuery = useWhiskyPairingsQuery(
+    10,
+    trimmedSearchKeyword,
+    CURATION_V2_SPEC_CODES.WHISKY_PAIRING,
+    isPairingTab,
+  );
   const tastingEventsQuery = useTastingEventsQuery(
     10,
     trimmedSearchKeyword,
     CURATION_V2_SPEC_CODES.WHISKY_TASTING_EVENT,
     isTastingEventTab,
   );
-  const activeQuery = isTastingEventTab
-    ? tastingEventsQuery
-    : isProgramTab
-      ? programsQuery
-      : curationsQuery;
-  const activeData = isTastingEventTab
-    ? tastingEventsQuery.data
-    : isProgramTab
-      ? programsQuery.data
-      : curationsQuery.data;
+
+  const activeTabState = (() => {
+    switch (currentTab.id) {
+      case CURATION_V2_SPEC_CODES.WHISKY_TASTING_EVENT:
+        return {
+          query: tastingEventsQuery,
+          data: tastingEventsQuery.data,
+          emptyMessage: '진행 중인 시음회가 없어요.',
+          errorMessage: '시음회 정보를 불러오지 못했어요.',
+          skeletonHeight: 'h-[390px]',
+        };
+      case CURATION_V2_SPEC_CODES.PROGRAM:
+        return {
+          query: programsQuery,
+          data: programsQuery.data,
+          emptyMessage: '등록된 프로그램이 없어요.',
+          errorMessage: '프로그램 정보를 불러오지 못했어요.',
+          skeletonHeight: 'h-[248px]',
+        };
+      case CURATION_V2_SPEC_CODES.WHISKY_PAIRING:
+        return {
+          query: pairingsQuery,
+          data: pairingsQuery.data,
+          emptyMessage: '등록된 페어링이 없어요.',
+          errorMessage: '페어링 정보를 불러오지 못했어요.',
+          skeletonHeight: 'h-[157px]',
+        };
+      case CURATION_V2_SPEC_CODES.RECOMMENDED_WHISKY:
+        return {
+          query: curationsQuery,
+          data: curationsQuery.data,
+          emptyMessage: '등록된 큐레이션이 없어요.',
+          errorMessage: '큐레이션 정보를 불러오지 못했어요.',
+          skeletonHeight: 'h-[157px]',
+        };
+    }
+  })();
+  const {
+    query: activeQuery,
+    data: activeData,
+    errorMessage,
+    skeletonHeight,
+  } = activeTabState;
   const emptyMessage = trimmedSearchKeyword
     ? '검색 결과가 없어요.'
-    : isTastingEventTab
-      ? '진행 중인 시음회가 없어요.'
-      : isProgramTab
-        ? '등록된 프로그램이 없어요.'
-        : '등록된 큐레이션이 없어요.';
-  const errorMessage = isTastingEventTab
-    ? '시음회 정보를 불러오지 못했어요.'
-    : isProgramTab
-      ? '프로그램 정보를 불러오지 못했어요.'
-      : '큐레이션 정보를 불러오지 못했어요.';
-  const skeletonHeight = isTastingEventTab
-    ? 'h-[390px]'
-    : isProgramTab
-      ? 'h-[248px]'
-      : 'h-[157px]';
+    : activeTabState.emptyMessage;
+
+  const renderFeedItems = () => {
+    switch (currentTab.id) {
+      case CURATION_V2_SPEC_CODES.WHISKY_TASTING_EVENT:
+        return tastingEventsQuery.data?.map((event, index) => (
+          <TastingEventFeedCard
+            key={event.id}
+            event={event}
+            priority={index === 0}
+          />
+        ));
+      case CURATION_V2_SPEC_CODES.PROGRAM:
+        return programsQuery.data?.map((program, index) => (
+          <ProgramFeedCard
+            key={program.id}
+            program={program}
+            priority={index === 0}
+          />
+        ));
+      case CURATION_V2_SPEC_CODES.WHISKY_PAIRING:
+        return pairingsQuery.data?.map((pairing, index) => (
+          <CurationFeedCard
+            key={pairing.id}
+            curation={pairing}
+            badgeLabel="페어링"
+            priority={index === 0}
+          />
+        ));
+      case CURATION_V2_SPEC_CODES.RECOMMENDED_WHISKY:
+        return curationsQuery.data?.map((curation, index) => (
+          <CurationFeedCard
+            key={curation.id}
+            curation={curation}
+            badgeLabel="큐레이션"
+            priority={index === 0}
+          />
+        ));
+    }
+  };
 
   return (
     <>
@@ -216,29 +287,7 @@ export default function CurationPage() {
           activeData &&
           activeData.length > 0 && (
             <div className="space-y-7 px-5 pb-navbar">
-              {isTastingEventTab
-                ? tastingEventsQuery.data?.map((event, index) => (
-                    <TastingEventFeedCard
-                      key={event.id}
-                      event={event}
-                      priority={index === 0}
-                    />
-                  ))
-                : isProgramTab
-                  ? programsQuery.data?.map((program, index) => (
-                      <ProgramFeedCard
-                        key={program.id}
-                        program={program}
-                        priority={index === 0}
-                      />
-                    ))
-                  : curationsQuery.data?.map((curation, index) => (
-                      <RecommendedCurationFeedCard
-                        key={curation.id}
-                        curation={curation}
-                        priority={index === 0}
-                      />
-                    ))}
+              {renderFeedItems()}
               {activeQuery.hasNextPage && (
                 <div ref={activeQuery.targetRef} className="h-1" />
               )}

--- a/src/queries/useWhiskyPairingsQuery.ts
+++ b/src/queries/useWhiskyPairingsQuery.ts
@@ -1,0 +1,23 @@
+import {
+  CURATION_V2_SPEC_CODES,
+  type CurationV2SpecCode,
+} from '@/api/curation-v2/constants';
+import { isWhiskyPairingFeedItem } from '@/api/curation-v2/guards';
+import { useCurationFeedQuery } from '@/queries/useCurationFeedQuery';
+
+export const useWhiskyPairingsQuery = (
+  pageSize = 10,
+  keyword?: string,
+  code: CurationV2SpecCode = CURATION_V2_SPEC_CODES.WHISKY_PAIRING,
+  enabled = true,
+) => {
+  const query = useCurationFeedQuery({ pageSize, keyword, code, enabled });
+  const data = query.data?.flatMap((page) =>
+    page.data.items.filter(isWhiskyPairingFeedItem),
+  );
+
+  return {
+    ...query,
+    data,
+  };
+};


### PR DESCRIPTION
## 작업 내용
- Product 큐레이션 화면에 WHISKY_PAIRING 탭과 전용 피드 조회를 추가했습니다.
- 페어링 상세를 기존 위스키 라인업 컴포넌트와 페어링 푸드 목록으로 구성했습니다.
- 추천/페어링 피드 카드를 공통 카드로 통합하고 상세 타입 판별을 spec code 기준으로 정리했습니다.
- 페어링 푸드 목록에 라이트/다크 시맨틱 컬러 토큰을 적용했습니다.

## 탭 노출 정책
- 전용 렌더러가 구현된 스펙은 등록 데이터가 없어도 탭과 빈 상태를 항상 노출합니다.
- 새 스펙은 활성 스펙 API만으로 자동 노출하지 않고, 전용 렌더러와 함께 명시적으로 추가합니다.

## 검증
- pnpm exec tsc --noEmit
- pnpm test --runInBand (66 suites, 308 tests)
- ESLint / Prettier / git diff --check

Closes bottle-note/workspace#346