### PR TITLE
[FE] 홈 동영상 배너 posterUrl 및 선택 슬라이드 지연 로딩

### DIFF
--- a/src/__tests__/components/HomeCarousel.test.tsx
+++ b/src/__tests__/components/HomeCarousel.test.tsx
@@ -1,10 +1,48 @@
-import { render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import HomeCarousel from '@/components/feature/home/HomeCarousel';
 import type { Banner } from '@/api/banner/types';
 
+interface MockCarouselApi {
+  canScrollPrev: () => boolean;
+  canScrollNext: () => boolean;
+  selectedScrollSnap: () => number;
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  on: (
+    event: string,
+    handler: (api: MockCarouselApi) => void,
+  ) => MockCarouselApi;
+  off: (
+    event: string,
+    handler: (api: MockCarouselApi) => void,
+  ) => MockCarouselApi;
+}
+
+let mockSelectedIndex = 0;
+const mockSelectHandlers = new Set<(api: MockCarouselApi) => void>();
+const mockCarouselApi: MockCarouselApi = {
+  canScrollPrev: jest.fn(() => true),
+  canScrollNext: jest.fn(() => true),
+  selectedScrollSnap: jest.fn(() => mockSelectedIndex),
+  scrollPrev: jest.fn(),
+  scrollNext: jest.fn(),
+  on: jest.fn((event: string, handler: (api: MockCarouselApi) => void) => {
+    if (event === 'select') {
+      mockSelectHandlers.add(handler);
+    }
+    return mockCarouselApi;
+  }),
+  off: jest.fn((event: string, handler: (api: MockCarouselApi) => void) => {
+    if (event === 'select') {
+      mockSelectHandlers.delete(handler);
+    }
+    return mockCarouselApi;
+  }),
+};
+
 jest.mock('embla-carousel-react', () => ({
   __esModule: true,
-  default: () => [jest.fn(), null],
+  default: () => [jest.fn(), mockCarouselApi],
 }));
 
 jest.mock('embla-carousel-autoplay', () => ({
@@ -20,6 +58,7 @@ const createBanner = (overrides: Partial<Banner> = {}): Banner => ({
   descriptionB: '',
   descriptionFontColor: '#000000',
   imageUrl: 'https://cdn.example.com/video.mp4',
+  posterUrl: null,
   textPosition: 'CENTER',
   targetUrl: '/test',
   isExternalUrl: false,
@@ -31,77 +70,148 @@ const createBanner = (overrides: Partial<Banner> = {}): Banner => ({
   ...overrides,
 });
 
-describe('HomeCarousel - 비디오 배너 poster', () => {
-  it('VIDEO 타입 배너에 poster 속성이 설정된다', () => {
-    const banner = createBanner({ mediaType: 'VIDEO' });
-    const { container } = render(<HomeCarousel banners={[banner]} />);
+const selectSlide = (index: number) => {
+  mockSelectedIndex = index;
+  act(() => {
+    mockSelectHandlers.forEach((handler) => handler(mockCarouselApi));
+  });
+};
 
-    const video = container.querySelector('video');
-    expect(video).not.toBeNull();
-    expect(video).toHaveAttribute('poster', '/images/banner-placeholder.webp');
+describe('HomeCarousel - 비디오 배너 poster 및 지연 로딩', () => {
+  beforeEach(() => {
+    mockSelectedIndex = 0;
+    mockSelectHandlers.clear();
+    jest.clearAllMocks();
   });
 
-  it('IMAGE 타입 배너에는 video 요소가 렌더링되지 않는다', () => {
+  it('VIDEO 배너에 API posterUrl을 적용한다', () => {
+    const banner = createBanner({
+      posterUrl: 'https://cdn.example.com/poster.webp',
+    });
+    const { container } = render(<HomeCarousel banners={[banner]} />);
+
+    expect(container.querySelector('video')).toHaveAttribute(
+      'poster',
+      banner.posterUrl,
+    );
+  });
+
+  it('hydration 전에 첫 영상이 준비됐으면 poster를 제거한다', () => {
+    const readyStateSpy = jest
+      .spyOn(HTMLMediaElement.prototype, 'readyState', 'get')
+      .mockReturnValue(HTMLMediaElement.HAVE_CURRENT_DATA);
+    const { container } = render(
+      <HomeCarousel
+        banners={[
+          createBanner({
+            posterUrl: 'https://cdn.example.com/poster.webp',
+          }),
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('img[aria-hidden="true"]')).toBeNull();
+    readyStateSpy.mockRestore();
+  });
+
+  it('posterUrl이 없으면 공통 placeholder를 사용한다', () => {
+    const { container } = render(
+      <HomeCarousel banners={[createBanner({ posterUrl: null })]} />,
+    );
+
+    expect(container.querySelector('video')).toHaveAttribute(
+      'poster',
+      '/images/banner-placeholder.webp',
+    );
+  });
+
+  it('poster 이미지 로드 실패 시 공통 placeholder로 교체한다', () => {
+    const { container } = render(
+      <HomeCarousel
+        banners={[
+          createBanner({
+            posterUrl: 'https://cdn.example.com/broken-poster.webp',
+          }),
+        ]}
+      />,
+    );
+
+    const posterImage = container.querySelector('img[aria-hidden="true"]');
+    fireEvent.error(posterImage!);
+
+    expect(container.querySelector('video')).toHaveAttribute(
+      'poster',
+      '/images/banner-placeholder.webp',
+    );
+  });
+
+  it('최초 선택된 VIDEO 배너만 src와 autoplay를 활성화한다', () => {
+    const banners = [
+      createBanner({
+        id: 1,
+        imageUrl: 'https://cdn.example.com/first.mp4',
+      }),
+      createBanner({
+        id: 2,
+        imageUrl: 'https://cdn.example.com/second.mp4',
+      }),
+    ];
+    const { container } = render(<HomeCarousel banners={banners} />);
+
+    const videos = container.querySelectorAll('video');
+    expect(videos[0]).toHaveAttribute('src', banners[0].imageUrl);
+    expect(videos[0]).toHaveAttribute('autoplay');
+    expect(videos[0]).toHaveAttribute('preload', 'auto');
+    expect(videos[1]).not.toHaveAttribute('src');
+    expect(videos[1]).not.toHaveAttribute('autoplay');
+    expect(videos[1]).toHaveAttribute('preload', 'none');
+  });
+
+  it('슬라이드 이동 시 새로 선택된 VIDEO 배너만 활성화한다', () => {
+    const banners = [
+      createBanner({
+        id: 1,
+        imageUrl: 'https://cdn.example.com/first.mp4',
+      }),
+      createBanner({
+        id: 2,
+        imageUrl: 'https://cdn.example.com/second.mp4',
+      }),
+    ];
+    const { container } = render(<HomeCarousel banners={banners} />);
+
+    selectSlide(1);
+
+    const videos = container.querySelectorAll('video');
+    expect(videos[0]).not.toHaveAttribute('src');
+    expect(videos[0]).not.toHaveAttribute('autoplay');
+    expect(videos[1]).toHaveAttribute('src', banners[1].imageUrl);
+    expect(videos[1]).toHaveAttribute('autoplay');
+  });
+
+  it('IMAGE 배너에는 video 요소가 렌더링되지 않는다', () => {
     const banner = createBanner({
       mediaType: 'IMAGE',
       imageUrl: 'https://cdn.example.com/image.webp',
     });
     const { container } = render(<HomeCarousel banners={[banner]} />);
 
-    const video = container.querySelector('video');
-    expect(video).toBeNull();
-
-    const img = container.querySelector('img');
-    expect(img).not.toBeNull();
+    expect(container.querySelector('video')).toBeNull();
+    expect(container.querySelector('img')).not.toBeNull();
   });
 
-  it('첫 번째 VIDEO 배너는 preload="auto"로 설정된다', () => {
-    const banners = [
-      createBanner({ id: 1, mediaType: 'VIDEO' }),
-      createBanner({ id: 2, mediaType: 'VIDEO' }),
-    ];
-    const { container } = render(<HomeCarousel banners={banners} />);
-
-    const videos = container.querySelectorAll('video');
-    expect(videos[0]).toHaveAttribute('preload', 'auto');
-    expect(videos[1]).toHaveAttribute('preload', 'none');
-  });
-
-  it('VIDEO 배너의 video 요소에 autoPlay, muted, loop, playsInline 속성이 있다', () => {
-    const banner = createBanner({ mediaType: 'VIDEO' });
-    const { container } = render(<HomeCarousel banners={[banner]} />);
+  it('VIDEO 배너에 muted, loop, playsInline 속성을 유지한다', () => {
+    const { container } = render(<HomeCarousel banners={[createBanner()]} />);
 
     const video = container.querySelector('video');
-    expect(video).toHaveAttribute('autoplay');
     expect(video).toHaveAttribute('playsinline');
-    // muted와 loop는 boolean attribute로 존재 확인
     expect(video?.muted).toBe(true);
     expect(video?.loop).toBe(true);
   });
 
-  it('SSR 초기 렌더 시 skeleton(로딩 placeholder)이 표시된다', () => {
-    const banner = createBanner({ mediaType: 'VIDEO' });
-    const { container } = render(<HomeCarousel banners={[banner]} />);
-
-    const skeleton = container.querySelector('.animate-pulse');
-    expect(skeleton).not.toBeNull();
-    expect(skeleton).toHaveClass('bg-bg-neutral-weak');
-  });
-
   it('빈 배너 배열이면 아무것도 렌더링하지 않는다', () => {
     const { container } = render(<HomeCarousel banners={[]} />);
+
     expect(container.innerHTML).toBe('');
-  });
-
-  it('poster 경로가 올바른 정적 파일을 가리킨다', () => {
-    const banner = createBanner({ mediaType: 'VIDEO' });
-    const { container } = render(<HomeCarousel banners={[banner]} />);
-
-    const video = container.querySelector('video');
-    const posterUrl = video?.getAttribute('poster');
-
-    // public/ 하위의 정적 파일 경로여야 한다
-    expect(posterUrl).toBe('/images/banner-placeholder.webp');
-    expect(posterUrl).toMatch(/\.webp$/);
   });
 });

--- a/src/api/banner/types.ts
+++ b/src/api/banner/types.ts
@@ -10,6 +10,7 @@ export interface Banner {
   descriptionB: string;
   descriptionFontColor: string;
   imageUrl: string;
+  posterUrl: string | null;
   textPosition: BannerTextPosition;
   targetUrl: string;
   isExternalUrl: boolean;

--- a/src/components/feature/home/HomeCarousel.tsx
+++ b/src/components/feature/home/HomeCarousel.tsx
@@ -24,15 +24,32 @@ const POSITION_CLASS: Record<BannerTextPosition, string> = {
 
 interface BannerImageProps {
   banner: Banner;
+  isActive: boolean;
   isPriority: boolean;
 }
 
 function BannerImage({
   banner,
+  isActive,
   isPriority,
   onError,
 }: BannerImageProps & { onError?: () => void }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [posterSrc, setPosterSrc] = useState(
+    banner.posterUrl || BANNER_VIDEO_POSTER,
+  );
+
+  useEffect(() => {
+    if (
+      banner.mediaType === 'VIDEO' &&
+      isActive &&
+      videoRef.current &&
+      videoRef.current.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
+    ) {
+      setIsLoaded(true);
+    }
+  }, [banner.mediaType, isActive]);
 
   if (banner.mediaType === 'VIDEO') {
     return (
@@ -42,17 +59,32 @@ function BannerImage({
         )}
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <video
-          src={banner.imageUrl}
-          poster={BANNER_VIDEO_POSTER}
-          autoPlay
+          ref={videoRef}
+          src={isActive ? banner.imageUrl : undefined}
+          poster={posterSrc}
+          autoPlay={isActive}
           muted
           loop
           playsInline
-          preload={isPriority ? 'auto' : 'none'}
+          preload={isActive ? 'auto' : 'none'}
           onLoadedData={() => setIsLoaded(true)}
           onError={onError}
           className="absolute inset-0 w-full h-full object-cover"
         />
+        {(!isActive || !isLoaded) && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={posterSrc}
+            alt=""
+            aria-hidden="true"
+            onError={() => {
+              if (posterSrc !== BANNER_VIDEO_POSTER) {
+                setPosterSrc(BANNER_VIDEO_POSTER);
+              }
+            }}
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+        )}
       </>
     );
   }
@@ -169,6 +201,7 @@ interface HomeCarouselProps {
 
 export default function HomeCarousel({ banners }: HomeCarouselProps) {
   const [api, setApi] = useState<CarouselApi | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [failedBannerIds, setFailedBannerIds] = useState<Set<number>>(
     new Set(),
   );
@@ -189,16 +222,20 @@ export default function HomeCarousel({ banners }: HomeCarouselProps) {
   );
 
   useEffect(() => {
-    if (!api || failedBannerIds.size === 0) return;
+    if (!api) return;
 
     const onSelect = () => {
       const currentIndex = api.selectedScrollSnap();
       const currentBanner = banners?.[currentIndex];
       if (currentBanner && failedBannerIds.has(currentBanner.id)) {
         api.scrollNext();
+        return;
       }
+
+      setSelectedIndex(currentIndex);
     };
 
+    onSelect();
     api.on('select', onSelect);
     return () => {
       api.off('select', onSelect);
@@ -237,6 +274,7 @@ export default function HomeCarousel({ banners }: HomeCarouselProps) {
             >
               <BannerImage
                 banner={banner}
+                isActive={index === selectedIndex}
                 isPriority={index === 0}
                 onError={() => handleBannerError(banner.id)}
               />


### PR DESCRIPTION
## 작업 내용
- Banner 응답 타입에 nullable posterUrl을 반영했습니다.
- 현재 선택된 VIDEO 슬라이드에만 src와 autoplay를 활성화했습니다.
- posterUrl 누락·로드 실패 시 공통 placeholder를 사용하도록 처리했습니다.
- 첫 영상이 hydration 전에 준비된 경우에도 poster가 정상적으로 제거되도록 보완했습니다.

## 검증
- pnpm test src/__tests__/components/HomeCarousel.test.tsx --runInBand
- pnpm exec tsc --noEmit
- pnpm exec next lint --file src/components/feature/home/HomeCarousel.tsx
- git diff --check

## 관련 이슈
- https://github.com/bottle-note/workspace/issues/356